### PR TITLE
Add a colored bar for markdown cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,28 @@ card_mod:
 </tr>
 </table>
 
+9. `bar` and `bar-right` -  blue bar (in Default theme) meant for Markdown cards
+<table>
+<tr>
+<td> YAML </td> <td> Result </td>
+</tr>
+<tr>
+<td>
+    
+```yaml
+type: markdown
+content: '# Bar'
+card_mod:
+  class: bar
+```
+
+</td>
+<td>
+<img width="350" alt="image" src="https://user-images.githubusercontent.com/25553648/211906842-0b6e04ac-fc50-4349-91fd-7fb2bc564f7b.png">
+</td>
+</tr>
+</table>
+
 ### Make your own color themes
 Custom themes can be created down at the bottom of `lcars.yaml`. Or, search for "===THEMES", which will take you right there. To create your own theme, copy the LCARS Default section to the bottom of the file and change the `lcars-ui-*` and `lcars-card-*` variables to your liking, using the color references at the top of the file, [The LCARS website](https://www.thelcars.com/colors.php), or define your own.
 

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -545,7 +545,7 @@
     ha-tabs, paper-tabs {
       --paper-tabs-selection-bar-color: transparent !important;
       border-left: solid black 4px;
-      margin-left: 4px !important;
+      margin-left: 22px !important;
     }
     /* Code for the clock */
     app-toolbar::after {
@@ -565,6 +565,34 @@
       border-right: 5px solid black;
       border-left: 5px solid black;
     }
+    @media screen and (max-width: 768px) {
+      app-toolbar::after {
+        content: "";
+        border-left: 0px solid black;
+      }
+      ha-button-menu > ha-icon-button {
+        margin-right: -48px;
+        padding-right: unset !important;
+        margin-left: unset !important;
+      }
+      .exit-edit-mode {
+        margin-right: 0px !important;
+      }
+      ha-icon-button {
+        padding-right: unset !important;
+        margin-left: unset !important;
+      }
+    }
+    /*@media screen and (max-width: 375px) {
+      app-toolbar::before {
+        margin-top: 77px !important;
+      }
+    }
+    @media screen and (max-width: 320px) {
+      app-toolbar::before {
+        margin-top: 74px !important;
+      }
+    }*/
     ha-menu-button {
       display: none !important;
       color: transparent;
@@ -618,7 +646,7 @@
     }
     app-toolbar::before {
       content: "";
-      position: inherit;
+      position: fixed;
       height: 40px;
       width: 100px;
       background-color: transparent;

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -488,52 +488,21 @@
       padding-bottom: 45px;
       color: black;
     }
-    ha-card.button-lozenge-right {
+    ha-card.bar {
       text-transform: uppercase;
-      color: black;
-      min-height: 60px;
+      border-right: 40px solid var(--lcars-card-top-color);
+      border-left: 40px solid var(--lcars-card-top-color);
+      background-color: var(--lcars-card-top-color);
       display: flex;
-      align-items: flex-start;
-      flex-direction: column-reverse;
     }
-    ha-card.button-bullet-right {
+    ha-card.bar-right {
       text-transform: uppercase;
-      color: black;
-      min-height: 60px;
-      border-radius: 40px 0px 0px 40px !important;
+      border-right: 40px solid var(--lcars-card-top-color);
+      border-left: 40px solid var(--lcars-card-top-color);
+      text-align: right;
+      background-color: var(--lcars-card-top-color);
       display: flex;
-      align-items: flex-start;
-      flex-direction: column-reverse;
-    }
-    ha-card.button-lozenge-right > ha-state-icon,
-    ha-card.button-bullet-right > ha-state-icon {
-      --mdc-icon-size: unset;
-      display: flex;
-      align-items: center;
-      right: 0;
-      width: 35px;
-      height: 100% !important;
-      border-left: black solid 6px;
-      position: absolute;
-      justify-content: center;
-      background: var(--lcars-card-top-color);
-    }
-    ha-card.button-lozenge-right > span,
-    ha-card.button-bullet-right > span {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: flex-end;
-      justify-content: flex-start;
-      margin-top: unset;
-      padding-left: 26px;
-      padding-bottom: 6px;
-      position: absolute;
-    }
-    ha-card.button-lozenge-right > span.state,
-    ha-card.button-bullet-right > span.state {
-      padding-bottom: 45px;
-      color: black;
+      justify-content: right
     }
     /* Hacky workaround to add middle-type class to horizontal and vertical stack cards */
     /* More info: https://github.com/thomasloven/lovelace-card-mod#styling-cards-without-an-ha-card-element */

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -590,16 +590,6 @@
         margin-left: -16px;
       }
     }
-    /*@media screen and (max-width: 375px) {
-      app-toolbar::before {
-        margin-top: 77px !important;
-      }
-    }
-    @media screen and (max-width: 320px) {
-      app-toolbar::before {
-        margin-top: 74px !important;
-      }
-    }*/
     ha-menu-button {
       display: none;
       color: transparent;

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -231,7 +231,6 @@
       padding-bottom: 0 !important;
     }
 
-
     /* Middle classes and fixes for specific cards */
     ha-card.middle {
       background: black !important;
@@ -263,7 +262,6 @@
     ha-card.middle-blank > ha-gauge {
       --primary-text-color: var(--lcars-text-gray);
     }
-
     ha-card.middle > .name, 
     ha-card.middle-right > .name, 
     ha-card.middle-contained > .name, 
@@ -417,7 +415,7 @@
       margin-top: -24px;
       position: relative;
     }
-    ha-card.button-small > ha-state-icon {
+    ha-card.button-small > ha-state-icon { /*wat*/
     }
     ha-card.button-small > span {
       box-sizing: border-box;
@@ -556,10 +554,10 @@
       padding-bottom: 0 !important;
     }
     /* Various generic card fixes */
-    .entities {
+    /*.entities {
       background: black;
       border-radius: 0px 0px 0px 20px;
-    }
+    }*/
     .type-thermostat > .content {
       background: black;
       border-radius: 0px 0px 0px 20px;
@@ -658,6 +656,7 @@
     app-toolbar {
       border-right: 30px solid var(--lcars-card-top-color);
       border-radius: 0px 30px 30px 0px;
+      margin-right: 1px;
     }
     ha-tabs, paper-tabs {
       --paper-tabs-selection-bar-color: transparent !important;

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -582,6 +582,13 @@
         padding-right: unset !important;
         margin-left: unset !important;
       }
+      ha-menu-button {
+        display: initial !important;
+        color: black !important;
+        padding-right: 0px !important;
+        margin-right: -22px;
+        margin-left: -16px;
+      }
     }
     /*@media screen and (max-width: 375px) {
       app-toolbar::before {
@@ -594,7 +601,7 @@
       }
     }*/
     ha-menu-button {
-      display: none !important;
+      display: none;
       color: transparent;
       padding-right: 10px
     }
@@ -772,9 +779,14 @@
       align-items: center;
     }
     .menu ha-icon-button {
-      color: var(--sidebar-icon-color);
       margin-top: 150px;
       margin-right: 96px;
+    }
+    @media screen and (max-width: 768px) {
+      .menu ha-icon-button {
+        margin-top: 0px;
+        margin-right: 0px;
+      }
     }
     .title {
       text-transform: uppercase;


### PR DESCRIPTION
This CSS code adds two colored bars like this:
![image](https://user-images.githubusercontent.com/25553648/211908296-ab7f3ace-af4c-4ce2-80c4-4222c959ddd9.png)