### PR TITLE
Add a new theme with option to remove gradients and noise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,17 @@ card_mod:
 Custom themes can be created down at the bottom of `lcars.yaml`. Or, search for "===THEMES", which will take you right there. To create your own theme, copy the LCARS Default section to the bottom of the file and change the `lcars-ui-*` and `lcars-card-*` variables to your liking, using the color references at the top of the file, [The LCARS website](https://www.thelcars.com/colors.php), or define your own.
 
 ### Noise and gradients
-If you're not feeling the subtle noise and gradients that this theme added, let me know by raising an issue. I am still working on an easy method to enable and disable them. You can remove them yourself by searching for "base64" and "-gradient" (you should find 3 entries each) and commenting/deleting the entire CSS blocks that contain them. [Feature request here](https://github.com/th3jesta/ha-lcars/issues/5).
+If you're not feeling the subtle noise and gradients that this theme added, you can disable them by adding an `input_boolean` entity to home assistant named `disable_theme_gradient` with the value of `on`.
+
+In YAML, this looks like:
+
+```yaml
+input_boolean:
+  disable_theme_gradient:
+    name: Disable Theme Gradient
+    icon: mdi:gradient-horizontal
+    initial: true
+```
 
 ## Tips and tricks
 _If you have anything to add here, create a PR with your tip and I will review it to add to this list._

--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ input_boolean:
     initial: true
 ```
 
+You may alternatively implement this through the UI by creating a helper of type `toggle`.
+
 ## Tips and tricks
 _If you have anything to add here, create a PR with your tip and I will review it to add to this list._
 * Make use of Vertical Stack cards. Whether in this theme or any other theme, they are invaluable for keeping dashboards organized. In LCARS, a Vertical Stack card should contain a Markdown card first with the title of the group and the `header` class applied, then any number of `middle` class cards and `button` class single buttons or in horizontal stacks or grids, and then finally a `footer` class applied to the last card in the vertical stack. You can see this formation in all of the screenshots at the top of this page. Here's an example Vertical Stack card and all of its contents:

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1357,6 +1357,8 @@ LCARS Zeldaar:
 
 LCARS Modern:
   card-mod-theme: LCARS Modern
+  # Custom colors
+  lcars-modern-light-gray: "#9996BA"
   <<: *lcars-colors
   <<: *base
   <<: *card-mod-css
@@ -1373,7 +1375,7 @@ LCARS Modern:
   lcars-ui-app-header-text-color: var(--lcars-c72)
   # Card colors
   lcars-card-top-color: var(--lcars-gold)
-  lcars-card-mid-left-color: "#9996BA"
+  lcars-card-mid-left-color: var(--lcars-modern-light-gray)
   lcars-card-button: var(--lcars-gray)
   lcars-card-bottom-color: var(--lcars-sky)
   # Misc

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -75,7 +75,7 @@
   lcars-c67: "#dd88dd"
   lcars-c68: "#ff0000"
   lcars-c69: "#cc0000"
-  lcars-70: "#ee0000"
+  lcars-c70: "#ee0000"
   lcars-c71: "#dfdfdf"
   lcars-c72: "#f7f7f7"
   lcars-lavender: "#cc88ff"
@@ -161,7 +161,7 @@
   paper-dialog-background-color: rgba(55, 55, 55)
   paper-item-icon-color: var(--lcars-dark-gray)
   more-info-header-background: rgba(25, 25, 25)
-  app-header-background-color: var(--lcars-ui-app-header-background-color)
+  app-header-background-color: var(--lcars-ui-app-header-background-color, var(--lcars-ui-primary))
   # Custom
   mini-media-player-base-color: var(--lcars-text-gray)
   mini-media-player-icon-color: var(--lcars-text-gray)
@@ -175,7 +175,7 @@
   switch-unchecked-track-color: var(--lcars-text-gray)
   switch-unchecked-button-color: var(--lcars-text-gray)
   header-height: 40px
-  app-header-text-color: var(--lcars-ui-app-header-text-color)
+  app-header-text-color: var(--lcars-ui-app-header-text-color, black)
   paper-tabs-selection-bar-color: transparent
   mdc-button-outline-color: transparent
   ha-config-card-border-radius: 40px
@@ -1218,9 +1218,6 @@ LCARS Default:
   lcars-ui-primary: var(--lcars-almond-creme)
   lcars-ui-secondary: var(--lcars-african-violet)
   lcars-ui-tertiary: var(--lcars-red)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-bluey)
   lcars-card-mid-left-color: var(--lcars-red)
@@ -1239,9 +1236,6 @@ LCARS Classic:
   lcars-ui-primary: var(--lcars-khaki)
   lcars-ui-secondary: var(--lcars-honey)
   lcars-ui-tertiary: var(--lcars-mars)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-violet)
   lcars-card-mid-left-color: var(--lcars-ice)
@@ -1260,9 +1254,6 @@ LCARS Nemesis Blue:
   lcars-ui-primary: var(--lcars-midnight)
   lcars-ui-secondary: var(--lcars-tangerine)
   lcars-ui-tertiary: var(--lcars-pumpkinshade)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-moonshine)
   lcars-card-mid-left-color: var(--lcars-evening)
@@ -1281,9 +1272,6 @@ LCARS Lower Decks:
   lcars-ui-primary: var(--lcars-gold)
   lcars-ui-secondary: var(--lcars-butter)
   lcars-ui-tertiary: var(--lcars-orange)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-october-sunset)
   lcars-card-mid-left-color: var(--lcars-harvestgold)
@@ -1302,9 +1290,6 @@ LCARS Romulus:
   lcars-ui-primary: var(--lcars-green)
   lcars-ui-secondary: var(--lcars-african-violet)
   lcars-ui-tertiary: var(--lcars-orange)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-cardinal)
   lcars-card-mid-left-color: var(--lcars-african-violet)
@@ -1323,9 +1308,6 @@ LCARS Kronos:
   lcars-ui-primary: var(--lcars-mars)
   lcars-ui-secondary: var(--lcars-gold)
   lcars-ui-tertiary: var(--lcars-orange)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-mars)
   lcars-card-mid-left-color: var(--lcars-october-sunset)
@@ -1344,9 +1326,6 @@ LCARS Cardassia:
   lcars-ui-primary: var(--lcars-c44)
   lcars-ui-secondary: var(--lcars-c55)
   lcars-ui-tertiary: var(--lcars-cardassia-maroon)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-c48)
   lcars-card-mid-left-color: var(--lcars-cardassia-maroon)
@@ -1366,9 +1345,6 @@ LCARS Zeldaar:
   lcars-ui-primary: var(--lcars-violet-creme)
   lcars-ui-secondary: var(--lcars-honey)
   lcars-ui-tertiary: var(--lcars-roseblush)
-  # Header colors
-  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
-  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-bluey)
   lcars-card-mid-left-color: var(--lcars-khaki)
@@ -1381,26 +1357,32 @@ LCARS Zeldaar:
 
 LCARS Modern:
   card-mod-theme: LCARS Modern
+  # Custom colors
+  # lcars-modern-blue: "#9A98FC"
+  # lcars-modern-light-gray: "#9996BA"
+  # lcars-modern-orange: "#E89924"
+  # lcars-modern-pink: "#C099CB"
+  # lcars-modern-purple: "#824E74"
   <<: *lcars-colors
   <<: *base
   <<: *card-mod-css
   # Primary colors
-  lcars-ui-primary: "#C099CB" # Pink
-  lcars-ui-secondary: "#9A98FC" # Blue
-  lcars-ui-tertiary: "#E89924" # Orange
+  lcars-ui-primary: var(--lcars-violet-creme)
+  lcars-ui-secondary: var(--lcars-sky)
+  lcars-ui-tertiary: var(--lcars-gold)
   # Header colors
   # specifying darker app header colors improves look on HA Apps (iphone/ipad/mac).
   # One unfortunate side effect is that pages without hui-root can't have heading styled
   # So, logbook, history, calendar, dev tools etc look a bit weird.
   # overall the cleaner look on dashboards is worth it in my opinion
   lcars-ui-app-header-background-color: rgba(39, 39, 39)
-  lcars-ui-app-header-text-color: white
+  lcars-ui-app-header-text-color: var(--lcars-c72)
   # Card colors
-  lcars-card-top-color: "#E89924" # Orange
-  lcars-card-mid-left-color: "#9996BA" # Light Gray
+  lcars-card-top-color: var(--lcars-gold)
+  lcars-card-mid-left-color: "#9996BA"
   lcars-card-button: var(--lcars-gray)
-  lcars-card-bottom-color: "#9A98FC" # Blue
+  lcars-card-bottom-color: var(--lcars-sky)
   # Misc
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
-  error-color: var(--lcars-red)
+  error-color: var(--lcars-c70)

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1371,7 +1371,7 @@ LCARS Modern:
   # One unfortunate side effect is that pages without hui-root can't have heading styled
   # So, logbook, history, calendar, dev tools etc look a bit weird.
   # overall the cleaner look on dashboards is worth it in my opinion
-  lcars-ui-app-header-background-color: rgba(39, 39, 39)
+  lcars-ui-app-header-background-color: "#272727"
   lcars-ui-app-header-text-color: var(--lcars-c72)
   # Card colors
   lcars-card-top-color: var(--lcars-gold)

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -161,7 +161,7 @@
   paper-dialog-background-color: rgba(55, 55, 55)
   paper-item-icon-color: var(--lcars-dark-gray)
   more-info-header-background: rgba(25, 25, 25)
-  app-header-background-color: var(--lcars-ui-primary)
+  app-header-background-color: var(--lcars-ui-app-header-background-color)
   # Custom
   mini-media-player-base-color: var(--lcars-text-gray)
   mini-media-player-icon-color: var(--lcars-text-gray)
@@ -175,7 +175,7 @@
   switch-unchecked-track-color: var(--lcars-text-gray)
   switch-unchecked-button-color: var(--lcars-text-gray)
   header-height: 40px
-  app-header-text-color: black
+  app-header-text-color: var(--lcars-ui-app-header-text-color)
   paper-tabs-selection-bar-color: transparent
   mdc-button-outline-color: transparent
   ha-config-card-border-radius: 40px
@@ -1218,6 +1218,9 @@ LCARS Default:
   lcars-ui-primary: var(--lcars-almond-creme)
   lcars-ui-secondary: var(--lcars-african-violet)
   lcars-ui-tertiary: var(--lcars-red)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-bluey)
   lcars-card-mid-left-color: var(--lcars-red)
@@ -1236,6 +1239,9 @@ LCARS Classic:
   lcars-ui-primary: var(--lcars-khaki)
   lcars-ui-secondary: var(--lcars-honey)
   lcars-ui-tertiary: var(--lcars-mars)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-violet)
   lcars-card-mid-left-color: var(--lcars-ice)
@@ -1254,6 +1260,9 @@ LCARS Nemesis Blue:
   lcars-ui-primary: var(--lcars-midnight)
   lcars-ui-secondary: var(--lcars-tangerine)
   lcars-ui-tertiary: var(--lcars-pumpkinshade)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-moonshine)
   lcars-card-mid-left-color: var(--lcars-evening)
@@ -1272,6 +1281,9 @@ LCARS Lower Decks:
   lcars-ui-primary: var(--lcars-gold)
   lcars-ui-secondary: var(--lcars-butter)
   lcars-ui-tertiary: var(--lcars-orange)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-october-sunset)
   lcars-card-mid-left-color: var(--lcars-harvestgold)
@@ -1290,6 +1302,9 @@ LCARS Romulus:
   lcars-ui-primary: var(--lcars-green)
   lcars-ui-secondary: var(--lcars-african-violet)
   lcars-ui-tertiary: var(--lcars-orange)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-cardinal)
   lcars-card-mid-left-color: var(--lcars-african-violet)
@@ -1308,6 +1323,9 @@ LCARS Kronos:
   lcars-ui-primary: var(--lcars-mars)
   lcars-ui-secondary: var(--lcars-gold)
   lcars-ui-tertiary: var(--lcars-orange)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-mars)
   lcars-card-mid-left-color: var(--lcars-october-sunset)
@@ -1326,6 +1344,9 @@ LCARS Cardassia:
   lcars-ui-primary: var(--lcars-c44)
   lcars-ui-secondary: var(--lcars-c55)
   lcars-ui-tertiary: var(--lcars-cardassia-maroon)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-c48)
   lcars-card-mid-left-color: var(--lcars-cardassia-maroon)
@@ -1345,6 +1366,9 @@ LCARS Zeldaar:
   lcars-ui-primary: var(--lcars-violet-creme)
   lcars-ui-secondary: var(--lcars-honey)
   lcars-ui-tertiary: var(--lcars-roseblush)
+  # Header colors
+  lcars-ui-app-header-background-color: var(--lcars-ui-primary)
+  lcars-ui-app-header-text-color: black
   # Card colors
   lcars-card-top-color: var(--lcars-bluey)
   lcars-card-mid-left-color: var(--lcars-khaki)
@@ -1360,17 +1384,17 @@ LCARS Modern:
   <<: *lcars-colors
   <<: *base
   <<: *card-mod-css
-  # specifying darker app header colors improves look on HA Apps (iphone/ipad/mac).
-  # One unfortunate side effect is that pages without hui-root can't have heading styled
-  # So, logbook, history, calendar, dev tools etc look a bit weird.
-  # overall the cleaner look on dashboards is worth it in my opinion
-  app-header-background-color: rgba(39, 39, 39)
-  app-header-text-color: white
-
   # Primary colors
   lcars-ui-primary: "#C099CB" # Pink
   lcars-ui-secondary: "#9A98FC" # Blue
   lcars-ui-tertiary: "#E89924" # Orange
+  # Header colors
+  # specifying darker app header colors improves look on HA Apps (iphone/ipad/mac).
+  # One unfortunate side effect is that pages without hui-root can't have heading styled
+  # So, logbook, history, calendar, dev tools etc look a bit weird.
+  # overall the cleaner look on dashboards is worth it in my opinion
+  lcars-ui-app-header-background-color: rgba(39, 39, 39)
+  lcars-ui-app-header-text-color: white
   # Card colors
   lcars-card-top-color: "#E89924" # Orange
   lcars-card-mid-left-color: "#9996BA" # Light Gray

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -862,6 +862,8 @@
       margin-left: -1px !important;
       borer-radius: 20px !important;
     }
+    app-header,
+    app-toolbar,
     .edit-mode app-toolbar {
       background: var(--lcars-ui-primary) !important;
     }
@@ -995,6 +997,7 @@
       cursor: pointer;
       z-index: 9999;
     }
+    {% if not is_state('input_boolean.disable_theme_gradient', 'on') %}
     app-header::before {
       content: linear-gradient(to left, transparent, #EEEEEE 30%, #222222 60%, transparent 90% );
       width: 100%;
@@ -1047,6 +1050,7 @@
       opacity: .8;
       pointer-events: none;
     }
+    {% endif %}
   card-mod-sidebar: &card-mod-sidebar |
     :host {
       content: "";
@@ -1173,6 +1177,7 @@
     paper-icon-item::before {
       opacity: 0 !important;
     }
+    {% if not is_state('input_boolean.disable_theme_gradient', 'on') %}
     paper-listbox::before {
       content: "";
       background: linear-gradient(to bottom left, transparent 10%, #AAAAAADD 30%, #000000AA 60%, transparent 90%);
@@ -1197,6 +1202,7 @@
       opacity: .8;
       pointer-events: none;
     }
+    {% endif %}
 # ===THEMES================================================
 # To create your own theme, copy this LCARS Default section
 # to the bottom of the file and change the lcars-ui-* and
@@ -1348,3 +1354,29 @@ LCARS Zeldaar:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+
+LCARS Modern:
+  card-mod-theme: LCARS Modern
+  <<: *lcars-colors
+  <<: *base
+  <<: *card-mod-css
+  # specifying darker app header colors improves look on HA Apps (iphone/ipad/mac).
+  # One unfortunate side effect is that pages without hui-root can't have heading styled
+  # So, logbook, history, calendar, dev tools etc look a bit weird.
+  # overall the cleaner look on dashboards is worth it in my opinion
+  app-header-background-color: rgba(39, 39, 39)
+  app-header-text-color: white
+
+  # Primary colors
+  lcars-ui-primary: "#C099CB" # Pink
+  lcars-ui-secondary: "#9A98FC" # Blue
+  lcars-ui-tertiary: "#E89924" # Orange
+  # Card colors
+  lcars-card-top-color: "#E89924" # Orange
+  lcars-card-mid-left-color: "#9996BA" # Light Gray
+  lcars-card-button: var(--lcars-gray)
+  lcars-card-bottom-color: "#9A98FC" # Blue
+  # Misc
+  success-color: var(--lcars-green)
+  warning-color: var(--lcars-sunflower)
+  error-color: var(--lcars-red)

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1357,12 +1357,6 @@ LCARS Zeldaar:
 
 LCARS Modern:
   card-mod-theme: LCARS Modern
-  # Custom colors
-  # lcars-modern-blue: "#9A98FC"
-  # lcars-modern-light-gray: "#9996BA"
-  # lcars-modern-orange: "#E89924"
-  # lcars-modern-pink: "#C099CB"
-  # lcars-modern-purple: "#824E74"
   <<: *lcars-colors
   <<: *base
   <<: *card-mod-css
@@ -1385,4 +1379,4 @@ LCARS Modern:
   # Misc
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
-  error-color: var(--lcars-c70)
+  error-color: var(--lcars-red)


### PR DESCRIPTION
### What's in this request

- A new theme called 'LCARS Modern'
- Functionality to disable Gradients and Noise (Resolves #5)
- Ability to redefine header color and text on a per-theme basis.

### Modern Theme

The modern theme is inspired by the [official LCARS apple watch face](https://www.facer.io/watchface/L7zN6lCsR8?watchModel=applewatchultraorange)

![Screenshot 2023-03-10 at 1 11 43 PM](https://user-images.githubusercontent.com/1561895/224392456-45d0d5ff-5a55-4e05-8677-8de001a48212.png)

### Remove Noise and Gradients

In order to get a cleaner look to the theme, I added the ability to turn off noise and gradients.

This has been accomplished by adding Jinja2 template conditions around the css containing the gradients and noise.  They reference an entity called `input_boolean.disable_theme_gradient`.  This entity is optional and if it does not exist the default behavior is to show the gradients.  If the entity exists and is set to `on` the noise and gradients will be turned off.  This seemed to be the cleanest solution as it has no impact on existing users and can be easily implemented by those wishing to disable this functionality.

I've also updated the readme documenting this.

### Allowing header color to be changed by the theme.

Currently, the `app-header-background-color` is fixed to display the primary ui color.  This looks fine in web browsers, but, in the ipad/iphone and desktop apps, the app header color also controls the look of the title bar for the application.  This results in a poor looking header (in my opinion).  See these two screenshots for comparison:

![Screenshot 2023-03-10 at 1 28 19 PM](https://user-images.githubusercontent.com/1561895/224395283-639982df-e3cf-4e38-8d56-45e7307f1299.png)

![Screenshot 2023-03-10 at 1 28 27 PM](https://user-images.githubusercontent.com/1561895/224395324-83825ae4-f593-4ebc-93e0-08ec4435072e.png)

Notice how in the second the title bar of the application doesn't bleed into the header of home assistant.  This does have a downside in that some non-dashboard HA pages (lookbook, history, developer tools, calendar) do not have a hui-root element so card mod doesn't provide a way to style app-toolbar and app-header.  Because of this, I created a couple of new variables called `lcars-ui-app-header-background-color` and `lcars-ui-app-header-text-color` which allow for overriding the header colors on a per-theme basis.  The the default values match the originals so there is no impact to any existing themes.

Incidentally, though I did not do it, I propose taking this approach for all variables in the base customization.  This will allow each variable to be overridden on a per theme basis.  I've noticed for example that certain themes have text contrast issues that cannot be easily fixed with the current structure.  This approach would allow each theme to override any of the global variables.


 