### PR TITLE
Eliminate extra logbook entries using correct time_date configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,6 @@ sensor:
   - platform: time_date
     display_options:
       - 'time'
-      - 'date'
-      - 'date_time'
-      - 'date_time_utc'
-      - 'date_time_iso'
-      - 'time_date'
-      - 'time_utc'
-      - 'beat'
 ```
 
 More info:


### PR DESCRIPTION
The configuration provided in the README results in A LOT of extra values being created in the logbook every minute.

The LCARS HA Theme [uses "time" from time_date in the clock(https://github.com/th3jesta/ha-lcars/blob/master/themes/lcars.yaml#L1030C29-L1030C40 ) so the rest are not needed.