### PR TITLE
Fix two sensor graph footer issues

### DIFF
--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -612,6 +612,10 @@
       ha-card.footer-contained.type-entity .footer,
       ha-card.footer-open.type-entity .footer {
         background: black;
+        overflow: hidden;
+        position: static;
+        flex-grow: 1;
+        align-content: end;
       }
       ha-card.footer-left.type-thermostat > .container,
       ha-card.footer-right.type-thermostat > .container,


### PR DESCRIPTION
Before: ![image](https://github.com/user-attachments/assets/bf75fc27-d27c-4e95-9555-33418c373dc6)
After: ![image](https://github.com/user-attachments/assets/4a485d3a-09ef-4ac1-af5c-650e93736315)

- If a (non-`open`) footer isn't full width, there is a gap between the `.info` and `.footer` elements that gets filled with the `background-color` (which is also what determines the inner-color color, so we can't just set it to `black`).
    - Fixed by using flexbox to make the footer element (but not the graph inside) grow to fill the gap.
- The graph draws on top of the inner corner, causing subtle discoloration.
    - Fixed by using `overflow: hidden` to clip the graph to the black region.

I originally discovered the first issue by creating a horizontal stack of two sensors at the end of a vertical stack. I noticed the second issue while investigating the first.

I may have put these rules in a more specific rule than would be ideal, but as far as I know this is the only situation with this issue. Graphs as headers have completely different brokenness that I'm less interested in personally investigating.

Test case:
```yaml
type: sensor
graph: line
entity: sensor.husky_battery_level
card_mod:
  class: middle-right
layout_options:
  grid_columns: 3
  grid_rows: 3
```