### PR TITLE
Fixes for 2025.10.0 HA

### DIFF
--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1393,27 +1393,27 @@
         text-transform: uppercase;
         font-family: var(--lcars-font);
       }
-      sl-tab-group {
+      ha-tab-group {
         margin-left: 30px;
         border-left: solid black 4px;
         --ha-tab-indicator-color: transparent !important;
         font-family: var(--lcars-font) !important;
         text-transform: uppercase;
       }
-      sl-tab {
+      ha-tab-group-tab {
         background: var(--lcars-ui-secondary);
         color: black;
         border-right: solid black 4px;
         height: 40px !important;
       }
-      sl-tab[aria-selected="true"],
-      sl-tab[active] {
+      ha-tab-group-tab[aria-selected="true"],
+      ha-tab-group-tab[active] {
         background: var(--lcars-ui-tertiary) !important;
       }
-      .edit-mode sl-tab[aria-selected=true]::part(base) {
+      .edit-mode ha-tab-group-tab[aria-selected=true]::part(base) {
         padding: 0px !important;
       }
-      .edit-mode sl-tab-group {
+      .edit-mode ha-tab-group {
         margin-left: 0px;
         border-left: none;
         height: 40px !important;


### PR DESCRIPTION
These fixes are per @3of9 on Discord. Find/Replace in order:
- sl-tab-group renamed to ha-tab-group
- sl-tab renamed to ha-tab-group-tab

Making this PR in case it's easier to just accept this PR. @th3jesta 