### PR TITLE
Fix overflow, colors, and fonts in settings, more-info, and dialogs

### DIFF
--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1293,6 +1293,11 @@
     "* $":
       .: |
         hass-subpage, hass-tabs-subpage {
+          --icon-primary-color: var(--sidebar-text-color);
+          --mdc-text-field-label-ink-color: var(--sidebar-text-color);
+          --mdc-text-field-ink-color: var(--sidebar-text-color);
+          font-family: var(--font-family);
+
           ha-card {
             overflow: hidden;
           }
@@ -1305,6 +1310,28 @@
         div.bottom-bar {
           --header-height: 50px;
         }
+
+  # ===================================================== #
+  #                 DIALOG MODIFICATIONS                  #
+  # ===================================================== #
+  card-mod-dialog-yaml: |
+    $: |
+      :host {
+        font-family: var(--font-family);
+      }
+  # ===================================================== #
+  #              MORE INFO MODIFICATIONS                  #
+  # ===================================================== #
+  card-mod-more-info-yaml: |
+    $: |
+      :host {
+        font-family: var(--font-family);
+      }
+
+    .: |
+      button.breadcrumb {
+        font-family: var(--font-family);
+      }
 
   # ===================================================== #
   #                 SIDEBAR MODIFICATIONS                 #

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1287,6 +1287,28 @@
       {% endif %}
 
   # ===================================================== #
+  #                 CONFIG MODIFICATIONS                  #
+  # ===================================================== #
+  card-mod-config-yaml: |
+    .: |
+      ha-config-integrations,
+      ha-config-devices,
+      ha-config-entities,
+      ha-config-helpers,
+      ha-config-automation,
+      ha-config-scene,
+      ha-config-script,
+      ha-config-blueprint,
+      ha-config-areas,
+      ha-config-labels,
+      ha-config-zone,
+      ha-config-voice-assistants,
+      zha-config-dashboard-router,
+      zwave_js-config-router {
+          --header-height: 50px;
+      }
+
+  # ===================================================== #
   #                 SIDEBAR MODIFICATIONS                 #
   # ===================================================== #
   card-mod-sidebar-yaml: &card-mod-sidebar |

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1290,25 +1290,21 @@
   #                 CONFIG MODIFICATIONS                  #
   # ===================================================== #
   card-mod-config-yaml: |
-    .: |
-      @media screen and (max-width: 870px) {
-        ha-config-integrations,
-        ha-config-devices,
-        ha-config-entities,
-        ha-config-helpers,
-        ha-config-automation,
-        ha-config-scene,
-        ha-config-script,
-        ha-config-blueprint,
-        ha-config-areas,
-        ha-config-labels,
-        ha-config-zone,
-        ha-config-voice-assistants,
-        zha-config-dashboard-router,
-        zwave_js-config-router {
-            --header-height: 50px;
+    "* $":
+      .: |
+        hass-subpage, hass-tabs-subpage {
+          ha-card {
+            overflow: hidden;
+          }
         }
-      }
+      "hass-tabs-subpage $": |
+        div.bottom-bar {
+          --header-height: 50px;
+        }
+      "hass-tabs-subpage-data-table $ hass-tabs-subpage $": |
+        div.bottom-bar {
+          --header-height: 50px;
+        }
 
   # ===================================================== #
   #                 SIDEBAR MODIFICATIONS                 #

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -1291,21 +1291,23 @@
   # ===================================================== #
   card-mod-config-yaml: |
     .: |
-      ha-config-integrations,
-      ha-config-devices,
-      ha-config-entities,
-      ha-config-helpers,
-      ha-config-automation,
-      ha-config-scene,
-      ha-config-script,
-      ha-config-blueprint,
-      ha-config-areas,
-      ha-config-labels,
-      ha-config-zone,
-      ha-config-voice-assistants,
-      zha-config-dashboard-router,
-      zwave_js-config-router {
-          --header-height: 50px;
+      @media screen and (max-width: 870px) {
+        ha-config-integrations,
+        ha-config-devices,
+        ha-config-entities,
+        ha-config-helpers,
+        ha-config-automation,
+        ha-config-scene,
+        ha-config-script,
+        ha-config-blueprint,
+        ha-config-areas,
+        ha-config-labels,
+        ha-config-zone,
+        ha-config-voice-assistants,
+        zha-config-dashboard-router,
+        zwave_js-config-router {
+            --header-height: 50px;
+        }
       }
 
   # ===================================================== #


### PR DESCRIPTION
Bumps the header size back up in the config menus so that the text isn't cropped. Unfortunately, the footer also uses --header-height and I couldn't find an elegant way to select only the footers. However, everywhere that this is applied the sidebar menu is not displayed so it never looks weird. 