### PR TITLE
Place stack titles in the border

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Color codes and font choice from https://www.thelcars.com
 
 # 🎉NEW FEATURES IN 4.0🎉
 ### Themed stacks 
-Vertical and horizontal stacks can now be themed. Examples include a horizontal stack header filled with buttons
-<p align="center"><img width="525" height="90" alt="image" src="https://github.com/user-attachments/assets/2ed71eb1-7de2-46be-a3ce-8b8183abd8fe" /></p>
+Vertical and horizontal stacks can now be themed and nested. Add a `header`, `middle`, or `footer` class and the stack title is placed in border
+<p align="center"><img width="500" alt="themed stacks" src="https://github.com/user-attachments/assets/3f20ba67-bf37-4477-a513-2417ea5f1176" /></p>
 
 ### Buttons as bars
 New classes ``button-bar-left`` and ``button-bar-right`` allow buttons to appear like the bars, including icons and states. Thanks [@bobzer](https://github.com/bobzer) for the idea!

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -988,6 +988,64 @@
       }
 
       /* =============================================== */
+      /*               STACK STYLES                      */
+      /* =============================================== */
+      :host(.type-vertical-stack),
+      :host(.type-horizontal-stack) {
+        position: relative;
+        .card-header {
+          padding: 0px;
+          position: absolute;
+          left: calc( 0px - var(--lcars-vertical-border) /2);
+          top: 50%;
+          transform: translate(-50%, -50%);
+          background-color: transparent;
+        }
+      }
+      :host(.header-right.type-horizontal-stack),
+      :host(.middle-right.type-horizontal-stack),
+      :host(.footer-right.type-horizontal-stack),
+      :host(.header-right.type-vertical-stack),
+      :host(.middle-right.type-vertical-stack),
+      :host(.footer-right.type-vertical-stack) {
+        .card-header {
+          transform: translate(50%, -50%);
+          left: unset;
+          right: calc( 0px - var(--lcars-vertical-border) /2);
+        }
+      }
+      :host(.header-left.type-horizontal-stack),
+      :host(.header-right.type-horizontal-stack),
+      :host(.header-contained.type-horizontal-stack),
+      :host(.header-left.type-horizontal-stack),
+      :host(.header-right.type-horizontal-stack),
+      :host(.header-contained.type-horizontal-stack) {
+        .card-header {
+          color: var(--lcars-card-top-text);
+        }
+      }
+      :host(.middle-left.type-horizontal-stack),
+      :host(.middle-right.type-horizontal-stack),
+      :host(.middle-contained.type-horizontal-stack),
+      :host(.middle-left.type-horizontal-stack),
+      :host(.middle-right.type-horizontal-stack),
+      :host(.middle-contained.type-horizontal-stack) {
+        .card-header {
+          color: var(--lcars-card-mid-left-text);
+        }
+      }
+      :host(.footer-left.type-horizontal-stack),
+      :host(.footer-right.type-horizontal-stack),
+      :host(.footer-contained.type-horizontal-stack),
+      :host(.footer-left.type-horizontal-stack),
+      :host(.footer-right.type-horizontal-stack),
+      :host(.footer-contained.type-horizontal-stack) {
+        .card-header {
+          color: var(--lcars-card-bottom-text);
+        }
+      }
+      
+      /* =============================================== */
       /*               MISCELLANEOUS STYLES              */
       /* =============================================== */
 

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -379,7 +379,7 @@
         background-color: var(--lcars-card-top-color);
         text-transform: uppercase;
 
-        > :not(style,card-mod) {
+        > :not(style,card-mod,h1) {
           border-radius: 0px;
           background-color: var(--lcars-background-color);
           padding-top: 6px;
@@ -452,7 +452,7 @@
         border-inline: 0px solid var(--lcars-card-mid-left-color);
         text-transform: uppercase;
 
-        > :not(style,card-mod) {
+        > :not(style,card-mod,h1) {
           border-radius: 0px;
           background-color: var(--lcars-background-color);
           --primary-text-color: var(--lcars-text-gray);
@@ -517,7 +517,7 @@
         background-color: var(--lcars-card-bottom-color);
         text-transform: uppercase;
 
-        > :not(style,card-mod) {
+        > :not(style,card-mod,h1) {
           border-radius: 0px;
           background-color: var(--lcars-background-color);
           padding-bottom: 6px;
@@ -939,7 +939,7 @@
         line-height: 1;
         overflow:hidden;
 
-        > :not(style,card-mod) {
+        > :not(style,card-mod,h1) {
           text-transform: uppercase;
           background-color: var(--lcars-background-color);
           border-radius: 0px;


### PR DESCRIPTION
Add support for stack titles by placing them in the middle of the side border. Left and contained classes use the left border. Right class uses the right border.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/93e2655f-1923-47e5-9104-c98fa6707556" />
