### PR TITLE
Updated script to flatten the theme file CSS for older iOS / Qt based Companion apps

### DIFF
--- a/py/flatten_ha_theme_css.py
+++ b/py/flatten_ha_theme_css.py
@@ -86,13 +86,22 @@ def normalise_css_source(text: str) -> str:
 
     for line in text.splitlines():
         stripped = line.lstrip()
+        # A line beginning with # inside CSS is usually an ID selector (#view,
+        # #item, #add-view).  The older version treated every such line as a
+        # commented-out CSS line and removed the hash, which broke the HA
+        # header/menu/sidebar selectors.  Real YAML/CSS comments should stay
+        # comments or disappear, not be converted into live CSS.
         if stripped.startswith("#"):
-            indent = line[: len(line) - len(stripped)]
-            uncommented = stripped[1:]
-            if uncommented.startswith(" "):
-                uncommented = uncommented[1:]
-            if uncommented.strip():
-                unhashed.append(indent + uncommented)
+            after_hash = stripped[1:].lstrip()
+            if after_hash.startswith((".", ":", "[", ">", "+", "~", "@")):
+                # Optional compatibility escape hatch: allow commented-out CSS
+                # fragments like '# .foo {' to be revived, but never '#id'.
+                indent = line[: len(line) - len(stripped)]
+                unhashed.append(indent + after_hash)
+            else:
+                # Preserve ID selectors and ignore ordinary YAML-style comments.
+                # The CSS parser will skip true comments; selectors remain intact.
+                unhashed.append(line)
             continue
         unhashed.append(line)
 
@@ -268,6 +277,45 @@ def normalise_selector(selector: str) -> str:
 
 
 
+def simplify_self_is_pseudo(selector: str) -> str:
+    """Simplify cases created by nesting such as ha-card.foo:is(ha-card).
+
+    CSS nesting often uses &:is(ha-card) to mean "the current element, when it is
+    an ha-card". A string-only expansion would concatenate the tag and produce
+    ha-card.fooha-card. This removes the :is(tag) part when the current compound
+    selector already starts with that tag.
+    """
+    pattern = re.compile(r":is\(([^()]*)\)")
+
+    def previous_compound(text: str, pos: int) -> str:
+        # Last compound selector before the pseudo, after combinators/commas/spaces.
+        j = pos - 1
+        while j >= 0 and text[j].isspace():
+            j -= 1
+        k = j
+        while k >= 0 and text[k] not in " >+~,{\n":
+            k -= 1
+        return text[k + 1:j + 1]
+
+    def repl(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        opts = [o.strip() for o in split_top_level_commas(inner)]
+        compound = previous_compound(selector, match.start())
+        tag_match = re.match(r"^[A-Za-z][\w-]*", compound)
+        if tag_match and any(o == tag_match.group(0) for o in opts):
+            remaining = [o for o in opts if o != tag_match.group(0)]
+            if not remaining:
+                return ""
+            return ":is(" + ", ".join(remaining) + ")"
+        return match.group(0)
+
+    previous = None
+    while previous != selector:
+        previous = selector
+        selector = pattern.sub(repl, selector)
+    return selector
+
+
 def expand_is_pseudo(selector: str) -> List[str]:
     """Expand simple :is(...) selector lists into separate selectors."""
     start = selector.find(":is(")
@@ -367,6 +415,9 @@ def rewrite_multi_not(selector: str) -> str:
 
 
 def clean_legacy_selector(selector: str) -> List[str]:
+    selector = simplify_self_is_pseudo(selector)
+    if ":has(" in selector:
+        return []
     selectors = expand_is_pseudo(selector)
     cleaned: List[str] = []
 
@@ -376,11 +427,25 @@ def clean_legacy_selector(selector: str) -> List[str]:
         item = re.sub(r">\s+:not\(", "> *:not(", item)
         item = re.sub(r"(#[A-Za-z0-9_-]+)(?:\1)+", r"\1", item)
 
-        if "ha-card." in item and ":not(div > *)" in item:
-            if not re.search(r"ha-card\.bar-large-(?:left|right)\b", item):
-                item = item.replace(":not(div > *)", "")
-                item = normalise_selector(item)
+        # Legacy selector engines do not support complex selectors inside :not().
+        # This rule used to spare bar-large-left/right, which left exactly the
+        # compatibility problem this script is supposed to remove.
+        if ":not(div > *)" in item:
+            # The source uses `ha-card:is(...):not(div > *)` to avoid styling
+            # nested/internal ha-cards. Simply deleting the complex :not() makes
+            # the rule much too broad and breaks the inner header rounding.
+            # For legacy selector engines, narrow those ha-card selectors to the
+            # direct card below the card-mod host instead.
+            item = re.sub(
+                r"(?<![\w-])ha-card((?:\.[A-Za-z0-9_-]+)+):not\(div > \*\)",
+                r":host > ha-card\1",
+                item,
+            )
+            item = item.replace(":not(div > *)", "")
+            item = normalise_selector(item)
 
+        if ";" in item or "__HA_CONTROL_LINE_" in item:
+            continue
         cleaned.append(item)
 
     out: List[str] = []
@@ -607,28 +672,23 @@ def render_flat_css(flat_rules: List[Tuple[List[str], List[str], List[str]]]) ->
 def flatten_css_block(css_text: str) -> str:
     cleaned = normalise_css_source(css_text)
 
-    control_line_mapping: Dict[str, str] = {}
+    # Jinja control lines are not CSS. If they are parsed as selectors, they get
+    # combined with their parent selector and produce invalid CSS such as
+    # ":host __HA_CONTROL_LINE_0__". Keep the CSS valid for legacy engines by
+    # removing those control lines before parsing. Template expressions inside
+    # declarations are still masked/restored below.
     protected_lines: List[str] = []
-    counter = 0
     for line in cleaned.splitlines():
         stripped = line.strip()
         if stripped.startswith("{%") and stripped.endswith("%}"):
-            token = f"__HA_CONTROL_LINE_{counter}__"
-            control_line_mapping[token] = stripped
-            protected_lines.append(token + " {\n  --ha-control-line: 1;\n}")
-            counter += 1
-        else:
-            protected_lines.append(line)
+            continue
+        protected_lines.append(line)
 
     masked, mapping = mask_templates("\n".join(protected_lines))
     parsed = parse_css(masked)
     flattened = flatten_css_rules(parsed)
     rendered = render_flat_css(flattened)
     restored = restore_templates(rendered, mapping)
-
-    for token, original in control_line_mapping.items():
-        pattern = rf"^\s*{re.escape(token)} \{{\n\s*--ha-control-line: 1;\n\}}\n?"
-        restored = re.sub(pattern, original + "\n", restored, flags=re.M)
 
     return restored
 
@@ -692,13 +752,58 @@ def indent_text(text: str, indent: int) -> str:
     return "".join(prefix + line if line.strip() else line for line in text.splitlines(keepends=True))
 
 
+def strip_has_pseudo_from_selector_text(text: str) -> str:
+    """Remove :has(...) from selector text without being fooled by nested parens."""
+    out: List[str] = []
+    i = 0
+    while i < len(text):
+        if text.startswith(":has(", i):
+            j = i + 5
+            depth = 0
+            quote = None
+            while j < len(text):
+                ch = text[j]
+                if quote is not None:
+                    if ch == "\\" and j + 1 < len(text):
+                        j += 2
+                        continue
+                    if ch == quote:
+                        quote = None
+                    j += 1
+                    continue
+                if ch in ("'", '"'):
+                    quote = ch
+                    j += 1
+                    continue
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    if depth == 0:
+                        j += 1
+                        break
+                    depth -= 1
+                j += 1
+            i = j
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def normalise_legacy_yaml_selector_line(line: str) -> str:
+    # card-mod also uses selector strings as YAML keys, e.g.
+    # "ha-card:has(ha-sortable)$": |. Older selector engines reject :has().
+    if ":has(" not in line:
+        return line
+    return strip_has_pseudo_from_selector_text(line)
+
 def process_text(text: str) -> str:
     lines = text.splitlines(keepends=True)
     out: List[str] = []
     i = 0
 
     while i < len(lines):
-        line = lines[i]
+        line = normalise_legacy_yaml_selector_line(lines[i])
         match = _LITERAL_RE.match(normalise_literal_marker_line_for_match(line.rstrip("\n")))
 
         if not match:
@@ -731,6 +836,132 @@ def process_text(text: str) -> str:
 
     return "".join(out)
 
+def insert_legacy_sidebar_menu_icon_centering(text: str) -> str:
+    """Add an old iOS/QtWebKit centering fix for sidebar menu icons."""
+
+    anchor = (
+        '      ha-user-badge {\n'
+        '        box-sizing: border-box;\n'
+        '        width: calc( var(--mdc-icon-size,24px) + 37px);\n'
+        '        padding-block: 8px;\n'
+        '      }\n'
+    )
+    fix = (
+        '\n'
+        '      ha-list-item-button:not(.configuration):not(.user) > ha-icon,\n'
+        '      ha-list-item-button:not(.configuration):not(.user) > ha-svg-icon {\n'
+        '        display: flex;\n'
+        '        align-items: center;\n'
+        '        justify-content: center;\n'
+        '        box-sizing: border-box;\n'
+        '        min-width: 61px;\n'
+        '        height: 100%;\n'
+        '      }\n'
+    )
+    if anchor in text:
+        return text.replace(anchor, anchor + fix, 1)
+
+
+def postprocess_lcars_compat(text: str) -> str:
+    """Repair cases where flattening creates CSS that is syntactically invalid or loses HA Jinja guards.
+
+    This is deliberately conservative: it removes selectors that can never match
+    because they combine :host(...) directly with a light-DOM ha-card/id, removes
+    orphaned comment tails from malformed source comments, and restores the two
+    standalone Home Assistant template guards used by lcars.yaml.
+    """
+    text = re.sub(r'^\s*\*[^\n]*\*/\s*\n', '', text, flags=re.M)
+
+    kept: List[str] = []
+    for line in text.splitlines(keepends=True):
+        if re.search(r':host\([^)]*\)(?:ha-card|#[A-Za-z0-9_-])', line):
+            continue
+        kept.append(line)
+    text = ''.join(kept)
+    text = re.sub(r',\n(\s*\{)', r'\n\1', text)
+
+    def find_block_end(source: str, start: int) -> int:
+        i = source.find('{', start)
+        if i < 0:
+            return -1
+        depth = 0
+        quote: Optional[str] = None
+        escaped = False
+        while i < len(source):
+            ch = source[i]
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif ch == '\\':
+                    escaped = True
+                elif ch == quote:
+                    quote = None
+            else:
+                if ch in ('"', "'"):
+                    quote = ch
+                elif ch == '{':
+                    depth += 1
+                elif ch == '}':
+                    depth -= 1
+                    if depth == 0:
+                        return i + 1
+            i += 1
+        return -1
+
+    drawer_anchor = '  card-mod-drawer: |\n'
+    drawer_index = text.find(drawer_anchor)
+    if drawer_index >= 0 and "{% if not is_state('input_boolean.lcars_texture', 'off') %}" not in text[drawer_index:drawer_index + 400]:
+        before_start = text.find('    :host::before {', drawer_index)
+        if before_start >= 0:
+            before_end = find_block_end(text, before_start)
+            after_start = text.find('    :host::after {', before_end)
+            if before_end >= 0 and after_start >= 0:
+                after_end = find_block_end(text, after_start)
+                if after_end >= 0:
+                    segment = text[before_start:after_end]
+                    wrapped = (
+                        "    {% if not is_state('input_boolean.lcars_texture', 'off') %}\n"
+                        + segment
+                        + "\n    {% endif %}"
+                    )
+                    text = text[:before_start] + wrapped + text[after_end:]
+
+    sound_pair = (
+        '      .header {\n'
+        '        --lcars-sound: false;\n'
+        '      }\n\n'
+        '      .header {\n'
+        '        --lcars-sound: true;\n'
+        '      }'
+    )
+    sound_guarded = (
+        "      {% if not is_state('input_boolean.lcars_sound', 'on') %}\n"
+        "      .header {\n"
+        "        --lcars-sound: false;\n"
+        "      }\n"
+        "      {% else %}\n"
+        "      .header {\n"
+        "        --lcars-sound: true;\n"
+        "      }\n"
+        "      {% endif %}"
+    )
+    text = text.replace(sound_pair, sound_guarded)
+
+    # Rewriting `:not(a,b,c)` to `:not(a):not(b):not(c)` is needed for
+    # older selector engines, but it increases selector specificity. In the
+    # header rules the common child reset then beats the later inner-radius
+    # rule. Footer worked because the source already used !important there.
+    # Make the corresponding header inner-radius declarations equally explicit.
+    text = text.replace(
+        'border-top-left-radius: var(--lcars-inner-radius);',
+        'border-top-left-radius: var(--lcars-inner-radius) !important;',
+    )
+    text = text.replace(
+        'border-top-right-radius: var(--lcars-inner-radius);',
+        'border-top-right-radius: var(--lcars-inner-radius) !important;',
+    )
+    text = insert_legacy_sidebar_menu_icon_centering(text)
+    return text
 
 def main() -> int:
     parser = argparse.ArgumentParser(
@@ -745,7 +976,7 @@ def main() -> int:
         parser.error("Use either --in-place or --output, not both.")
 
     source = args.input.read_text(encoding="utf-8")
-    transformed = process_text(source)
+    transformed = postprocess_lcars_compat(process_text(source))
 
     if args.in_place:
         args.input.write_text(transformed, encoding="utf-8")

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -2630,14 +2630,6 @@ LCARS 25C:
   # Theme-specific
   lcars-tab-selected-bg: url("data:image/svg+xml,%3C!-- sample rectangle --%3E%3Csvg width='256' height='256' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='100%25' height='100%25' fill='transparent'%3E%3Canimate attributeName='fill' values='%23e7442a;%23e7442a;%236d748c' begin='0s' dur='5s' calcMode='discrete' repeatCount='indefinite' /%3E%3C/rect%3E%3C/svg%3E")
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -2646,6 +2638,14 @@ LCARS 25C:
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS 25C (Blue Alert):
   card-mod-theme: LCARS 25C (Blue Alert)
@@ -2705,15 +2705,6 @@ LCARS 25C (Blue Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "34,102,255"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
-      lcars-ui-tertiary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -2723,6 +2714,15 @@ LCARS 25C (Blue Alert):
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-tertiary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
+      lcars-ui-tertiary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS 25C (Red Alert):
   card-mod-theme: LCARS 25C (Red Alert)
@@ -2782,18 +2782,18 @@ LCARS 25C (Red Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "204,0,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS 25C (Yellow Alert):
   card-mod-theme: LCARS 25C (Yellow Alert)
@@ -2853,18 +2853,18 @@ LCARS 25C (Yellow Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "255,170,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Breen:
   card-mod-theme: LCARS Breen
@@ -2923,18 +2923,18 @@ LCARS Breen:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Cardassia:
   card-mod-theme: LCARS Cardassia
@@ -2993,18 +2993,18 @@ LCARS Cardassia:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "79,26,35"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Classic:
   card-mod-theme: LCARS Classic
@@ -3063,13 +3063,6 @@ LCARS Classic:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3077,6 +3070,13 @@ LCARS Classic:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Default:
   card-mod-theme: LCARS Default
@@ -3135,13 +3135,6 @@ LCARS Default:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3149,6 +3142,13 @@ LCARS Default:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Kronos:
   card-mod-theme: LCARS Kronos
@@ -3207,18 +3207,18 @@ LCARS Kronos:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "147,10,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Picard [LCARdS Blue Accent]:
   card-mod-theme: LCARS Picard [LCARdS Blue Accent]
@@ -3340,21 +3340,6 @@ LCARS Picard [LCARdS Blue Accent]:
   lcars-card-button-barrel: var(--lcards-gray-medium-dark)
   lcars-card-background: var(--lcards-gray-medium-light)
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
-      lcars-ui-primary: var(--lcards-gray-medium-light)
-      lcars-ui-secondary: var(--lcards-gray-light)
-      lcars-ui-tertiary: var(--lcards-blue)
-      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
-      lcars-alert-color: var(--lcards-orange-medium-dark)
-      success-color: var(--lcards-green)
-      warning-color: var(--lcards-orange-medium-light)
-      error-color: var(--lcards-orange)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3370,6 +3355,21 @@ LCARS Picard [LCARdS Blue Accent]:
       success-color: var(--lcards-green)
       warning-color: var(--lcards-orange)
       error-color: var(--lcards-orange-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
+      lcars-ui-primary: var(--lcards-gray-medium-light)
+      lcars-ui-secondary: var(--lcards-gray-light)
+      lcars-ui-tertiary: var(--lcards-blue)
+      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
+      lcars-alert-color: var(--lcards-orange-medium-dark)
+      success-color: var(--lcards-green)
+      warning-color: var(--lcards-orange-medium-light)
+      error-color: var(--lcards-orange)
 
 LCARS Picard [LCARdS Red Accent]:
   card-mod-theme: LCARS Picard [LCARdS Red Accent]
@@ -3491,21 +3491,6 @@ LCARS Picard [LCARdS Red Accent]:
   lcars-card-button-barrel: var(--lcards-gray-medium-dark)
   lcars-card-background: var(--lcards-gray-medium-light)
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
-      lcars-ui-primary: var(--lcards-gray-medium-light)
-      lcars-ui-secondary: var(--lcards-gray-light)
-      lcars-ui-tertiary: var(--lcards-orange)
-      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
-      lcars-alert-color: var(--lcards-orange-medium-dark)
-      success-color: var(--lcards-green)
-      warning-color: var(--lcards-orange-medium-light)
-      error-color: var(--lcards-orange)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3521,6 +3506,21 @@ LCARS Picard [LCARdS Red Accent]:
       success-color: var(--lcards-green)
       warning-color: var(--lcards-orange)
       error-color: var(--lcards-orange-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
+      lcars-ui-primary: var(--lcards-gray-medium-light)
+      lcars-ui-secondary: var(--lcards-gray-light)
+      lcars-ui-tertiary: var(--lcards-orange)
+      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
+      lcars-alert-color: var(--lcards-orange-medium-dark)
+      success-color: var(--lcards-green)
+      warning-color: var(--lcards-orange-medium-light)
+      error-color: var(--lcards-orange)
 
 LCARS Lower Decks I:
   card-mod-theme: LCARS Lower Decks I
@@ -3579,18 +3579,18 @@ LCARS Lower Decks I:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Lower Decks II:
   card-mod-theme: LCARS Lower Decks II
@@ -3649,18 +3649,18 @@ LCARS Lower Decks II:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Modern:
   card-mod-theme: LCARS Modern
@@ -3719,13 +3719,6 @@ LCARS Modern:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3733,6 +3726,13 @@ LCARS Modern:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Navigation:
   card-mod-theme: LCARS Navigation
@@ -3791,18 +3791,18 @@ LCARS Navigation:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "130,122,83"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Nemesis Blue:
   card-mod-theme: LCARS Nemesis Blue
@@ -3861,13 +3861,6 @@ LCARS Nemesis Blue:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3875,6 +3868,13 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
 
 LCARS Picard I:
   card-mod-theme: LCARS Picard I
@@ -3933,14 +3933,6 @@ LCARS Picard I:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "101,107,131"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-secondary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3949,6 +3941,14 @@ LCARS Picard I:
       lcars-backlight-outer: "#00000080"
       lcars-ui-secondary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-secondary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Picard II:
   card-mod-theme: LCARS Picard II
@@ -4007,18 +4007,18 @@ LCARS Picard II:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "1,37,86"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Red Alert:
   card-mod-theme: LCARS Red Alert
@@ -4077,13 +4077,6 @@ LCARS Red Alert:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "54,0,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4091,6 +4084,13 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
 
 LCARS Romulus:
   card-mod-theme: LCARS Romulus
@@ -4149,18 +4149,18 @@ LCARS Romulus:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS TNG:
   card-mod-theme: LCARS TNG
@@ -4219,18 +4219,18 @@ LCARS TNG:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS TNGbuttons:
   card-mod-theme: LCARS TNGbuttons
@@ -4289,18 +4289,18 @@ LCARS TNGbuttons:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Transporter:
   card-mod-theme: LCARS Transporter
@@ -4359,13 +4359,6 @@ LCARS Transporter:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "44,55,75"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-secondary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4373,6 +4366,13 @@ LCARS Transporter:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-secondary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-secondary-text: var(--lcars-text-light)
 
 LCARS Zeldaar:
   card-mod-theme: LCARS Zeldaar
@@ -4431,18 +4431,18 @@ LCARS Zeldaar:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "119,68,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 # ================ Paste your themes here =============== |
 # (or add a file to src/themes/ and run generate_themes.py)

--- a/themes/lcars_flat.yaml
+++ b/themes/lcars_flat.yaml
@@ -3346,14 +3346,6 @@ LCARS 25C:
   # Theme-specific
   lcars-tab-selected-bg: url("data:image/svg+xml,%3C!-- sample rectangle --%3E%3Csvg width='256' height='256' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='100%25' height='100%25' fill='transparent'%3E%3Canimate attributeName='fill' values='%23e7442a;%23e7442a;%236d748c' begin='0s' dur='5s' calcMode='discrete' repeatCount='indefinite' /%3E%3C/rect%3E%3C/svg%3E")
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3362,6 +3354,14 @@ LCARS 25C:
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS 25C (Blue Alert):
   card-mod-theme: LCARS 25C (Blue Alert)
@@ -3421,15 +3421,6 @@ LCARS 25C (Blue Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "34,102,255"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
-      lcars-ui-tertiary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3439,6 +3430,15 @@ LCARS 25C (Blue Alert):
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-tertiary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
+      lcars-ui-tertiary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS 25C (Red Alert):
   card-mod-theme: LCARS 25C (Red Alert)
@@ -3498,18 +3498,18 @@ LCARS 25C (Red Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "204,0,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS 25C (Yellow Alert):
   card-mod-theme: LCARS 25C (Yellow Alert)
@@ -3569,18 +3569,18 @@ LCARS 25C (Yellow Alert):
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "255,170,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Breen:
   card-mod-theme: LCARS Breen
@@ -3639,18 +3639,18 @@ LCARS Breen:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Cardassia:
   card-mod-theme: LCARS Cardassia
@@ -3709,18 +3709,18 @@ LCARS Cardassia:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "79,26,35"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Classic:
   card-mod-theme: LCARS Classic
@@ -3779,13 +3779,6 @@ LCARS Classic:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3793,6 +3786,13 @@ LCARS Classic:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Default:
   card-mod-theme: LCARS Default
@@ -3851,13 +3851,6 @@ LCARS Default:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3865,6 +3858,13 @@ LCARS Default:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Kronos:
   card-mod-theme: LCARS Kronos
@@ -3923,18 +3923,18 @@ LCARS Kronos:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "147,10,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Picard [LCARdS Blue Accent]:
   card-mod-theme: LCARS Picard [LCARdS Blue Accent]
@@ -4056,21 +4056,6 @@ LCARS Picard [LCARdS Blue Accent]:
   lcars-card-button-barrel: var(--lcards-gray-medium-dark)
   lcars-card-background: var(--lcards-gray-medium-light)
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
-      lcars-ui-primary: var(--lcards-gray-medium-light)
-      lcars-ui-secondary: var(--lcards-gray-light)
-      lcars-ui-tertiary: var(--lcards-blue)
-      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
-      lcars-alert-color: var(--lcards-orange-medium-dark)
-      success-color: var(--lcards-green)
-      warning-color: var(--lcards-orange-medium-light)
-      error-color: var(--lcards-orange)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4086,6 +4071,21 @@ LCARS Picard [LCARdS Blue Accent]:
       success-color: var(--lcards-green)
       warning-color: var(--lcards-orange)
       error-color: var(--lcards-orange-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
+      lcars-ui-primary: var(--lcards-gray-medium-light)
+      lcars-ui-secondary: var(--lcards-gray-light)
+      lcars-ui-tertiary: var(--lcards-blue)
+      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
+      lcars-alert-color: var(--lcards-orange-medium-dark)
+      success-color: var(--lcards-green)
+      warning-color: var(--lcards-orange-medium-light)
+      error-color: var(--lcards-orange)
 
 LCARS Picard [LCARdS Red Accent]:
   card-mod-theme: LCARS Picard [LCARdS Red Accent]
@@ -4207,21 +4207,6 @@ LCARS Picard [LCARdS Red Accent]:
   lcars-card-button-barrel: var(--lcards-gray-medium-dark)
   lcars-card-background: var(--lcards-gray-medium-light)
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
-      lcars-ui-primary: var(--lcards-gray-medium-light)
-      lcars-ui-secondary: var(--lcards-gray-light)
-      lcars-ui-tertiary: var(--lcards-orange)
-      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
-      lcars-alert-color: var(--lcards-orange-medium-dark)
-      success-color: var(--lcards-green)
-      warning-color: var(--lcards-orange-medium-light)
-      error-color: var(--lcards-orange)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4237,6 +4222,21 @@ LCARS Picard [LCARdS Red Accent]:
       success-color: var(--lcards-green)
       warning-color: var(--lcards-orange)
       error-color: var(--lcards-orange-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
+      lcars-ui-primary: var(--lcards-gray-medium-light)
+      lcars-ui-secondary: var(--lcards-gray-light)
+      lcars-ui-tertiary: var(--lcards-orange)
+      lcars-ui-quaternary: var(--lcards-gray-medium-dark)
+      lcars-alert-color: var(--lcards-orange-medium-dark)
+      success-color: var(--lcards-green)
+      warning-color: var(--lcards-orange-medium-light)
+      error-color: var(--lcards-orange)
 
 LCARS Lower Decks I:
   card-mod-theme: LCARS Lower Decks I
@@ -4295,18 +4295,18 @@ LCARS Lower Decks I:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Lower Decks II:
   card-mod-theme: LCARS Lower Decks II
@@ -4365,18 +4365,18 @@ LCARS Lower Decks II:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Modern:
   card-mod-theme: LCARS Modern
@@ -4435,13 +4435,6 @@ LCARS Modern:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4449,6 +4442,13 @@ LCARS Modern:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Navigation:
   card-mod-theme: LCARS Navigation
@@ -4507,18 +4507,18 @@ LCARS Navigation:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "130,122,83"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Nemesis Blue:
   card-mod-theme: LCARS Nemesis Blue
@@ -4577,13 +4577,6 @@ LCARS Nemesis Blue:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4591,6 +4584,13 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
 
 LCARS Picard I:
   card-mod-theme: LCARS Picard I
@@ -4649,14 +4649,6 @@ LCARS Picard I:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "101,107,131"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-secondary-text: var(--lcars-text-light)
-      lcars-ui-quaternary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4665,6 +4657,14 @@ LCARS Picard I:
       lcars-backlight-outer: "#00000080"
       lcars-ui-secondary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-secondary-text: var(--lcars-text-light)
+      lcars-ui-quaternary-text: var(--lcars-text-light)
 
 LCARS Picard II:
   card-mod-theme: LCARS Picard II
@@ -4723,18 +4723,18 @@ LCARS Picard II:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "1,37,86"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Red Alert:
   card-mod-theme: LCARS Red Alert
@@ -4793,13 +4793,6 @@ LCARS Red Alert:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "54,0,0"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-primary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4807,6 +4800,13 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-primary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-primary-text: var(--lcars-text-light)
 
 LCARS Romulus:
   card-mod-theme: LCARS Romulus
@@ -4865,18 +4865,18 @@ LCARS Romulus:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS TNG:
   card-mod-theme: LCARS TNG
@@ -4935,18 +4935,18 @@ LCARS TNG:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS TNGbuttons:
   card-mod-theme: LCARS TNGbuttons
@@ -5005,18 +5005,18 @@ LCARS TNGbuttons:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 LCARS Transporter:
   card-mod-theme: LCARS Transporter
@@ -5075,13 +5075,6 @@ LCARS Transporter:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "44,55,75"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
-      lcars-ui-secondary-text: var(--lcars-text-light)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5089,6 +5082,13 @@ LCARS Transporter:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-ui-secondary-text: var(--lcars-text-dark)
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
+      lcars-ui-secondary-text: var(--lcars-text-light)
 
 LCARS Zeldaar:
   card-mod-theme: LCARS Zeldaar
@@ -5147,18 +5147,18 @@ LCARS Zeldaar:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "119,68,119"
   modes:
-    light:
-      lcars-ui-mix-color: black
-      lcars-backlight-center: "#ffffff30"
-      lcars-backlight-middle: transparent
-      lcars-backlight-middle-location: 60%
-      lcars-backlight-outer: transparent
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
       lcars-backlight-middle: transparent
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
+    light:
+      lcars-ui-mix-color: black
+      lcars-backlight-center: "#ffffff30"
+      lcars-backlight-middle: transparent
+      lcars-backlight-middle-location: 60%
+      lcars-backlight-outer: transparent
 
 # ================ Paste your themes here =============== |
 # (or add a file to src/themes/ and run generate_themes.py)

--- a/themes/lcars_flat.yaml
+++ b/themes/lcars_flat.yaml
@@ -409,10 +409,7 @@
 # ======================================================= #
 (DO NOT USE/MODIFY)=== card-mod CSS: &card-mod-css # Card modifications
   card-mod-drawer: |
-    :host __HA_CONTROL_LINE_0__ {
-      --ha-control-line: 1;
-    }
-
+    {% if not is_state('input_boolean.lcars_texture', 'off') %}
     :host::before {
       content: radial-gradient(ellipse farthest-corner at center center, var(--lcars-backlight-center) 0%, var(--lcars-backlight-middle) var(--lcars-backlight-middle-location), var(--lcars-backlight-outer) 100%);
       width: 100%;
@@ -436,14 +433,10 @@
       opacity: 1;
       pointer-events: none;
     }
-
-    :host __HA_CONTROL_LINE_1__ {
-      --ha-control-line: 1;
-    }
+    {% endif %}
   card-mod-card-yaml: &card-mod-card |
     .: |
       :host {
-        * Default card has quaternary background. */
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;
         --lcars-primary-text: var(--lcars-ui-quaternary-text) !important;
@@ -471,10 +464,10 @@
       :host(.header-right),
       :host(.header-contained),
       :host(.header-open),
-      ha-card.header-left,
-      ha-card.header-right,
-      ha-card.header-contained,
-      ha-card.header-open {
+      :host > ha-card.header-left,
+      :host > ha-card.header-right,
+      :host > ha-card.header-contained,
+      :host > ha-card.header-open {
         display: block !important;
         height: 100%;
         border: 0px solid var(--lcars-card-top-color);
@@ -490,10 +483,10 @@
       :host(.header-right) > *:not(style):not(card-mod):not(h1),
       :host(.header-contained) > *:not(style):not(card-mod):not(h1),
       :host(.header-open) > *:not(style):not(card-mod):not(h1),
-      ha-card.header-left > *:not(style):not(card-mod):not(h1),
-      ha-card.header-right > *:not(style):not(card-mod):not(h1),
-      ha-card.header-contained > *:not(style):not(card-mod):not(h1),
-      ha-card.header-open > *:not(style):not(card-mod):not(h1) {
+      :host > ha-card.header-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-open > *:not(style):not(card-mod):not(h1) {
         background-color: var(--lcars-background-color);
         --lcars-primary-text: var(--lcars-background-text);
         --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
@@ -523,46 +516,46 @@
       :host(.header-contained) > ha-card > ha-markdown,
       :host(.header-open) > ha-markdown,
       :host(.header-open) > ha-card > ha-markdown,
-      ha-card.header-left > ha-markdown,
-      ha-card.header-left > ha-card > ha-markdown,
-      ha-card.header-right > ha-markdown,
-      ha-card.header-right > ha-card > ha-markdown,
-      ha-card.header-contained > ha-markdown,
-      ha-card.header-contained > ha-card > ha-markdown,
-      ha-card.header-open > ha-markdown,
-      ha-card.header-open > ha-card > ha-markdown {
+      :host > ha-card.header-left > ha-markdown,
+      :host > ha-card.header-left > ha-card > ha-markdown,
+      :host > ha-card.header-right > ha-markdown,
+      :host > ha-card.header-right > ha-card > ha-markdown,
+      :host > ha-card.header-contained > ha-markdown,
+      :host > ha-card.header-contained > ha-card > ha-markdown,
+      :host > ha-card.header-open > ha-markdown,
+      :host > ha-card.header-open > ha-card > ha-markdown {
         padding-block: 0px;
       }
 
       :host(.header-left),
       :host(.header-contained),
-      ha-card.header-left,
-      ha-card.header-contained {
+      :host > ha-card.header-left,
+      :host > ha-card.header-contained {
         border-top-left-radius: var(--ha-card-border-radius);
         border-left-width: var(--lcars-vertical-border);
       }
 
       :host(.header-left) > *:not(style):not(card-mod),
       :host(.header-contained) > *:not(style):not(card-mod),
-      ha-card.header-left > *:not(style):not(card-mod),
-      ha-card.header-contained > *:not(style):not(card-mod) {
-        border-top-left-radius: var(--lcars-inner-radius);
+      :host > ha-card.header-left > *:not(style):not(card-mod),
+      :host > ha-card.header-contained > *:not(style):not(card-mod) {
+        border-top-left-radius: var(--lcars-inner-radius) !important;
         padding-left: 6px;
       }
 
       :host(.header-right),
       :host(.header-contained),
-      ha-card.header-right,
-      ha-card.header-contained {
+      :host > ha-card.header-right,
+      :host > ha-card.header-contained {
         border-top-right-radius: var(--ha-card-border-radius);
         border-right-width: var(--lcars-vertical-border);
       }
 
       :host(.header-right) > *:not(style):not(card-mod),
       :host(.header-contained) > *:not(style):not(card-mod),
-      ha-card.header-right > *:not(style):not(card-mod),
-      ha-card.header-contained > *:not(style):not(card-mod) {
-        border-top-right-radius: var(--lcars-inner-radius);
+      :host > ha-card.header-right > *:not(style):not(card-mod),
+      :host > ha-card.header-contained > *:not(style):not(card-mod) {
+        border-top-right-radius: var(--lcars-inner-radius) !important;
         padding-right: 6px;
       }
 
@@ -570,10 +563,10 @@
       :host(.middle-right),
       :host(.middle-contained),
       :host(.middle-blank),
-      ha-card.middle-left,
-      ha-card.middle-right,
-      ha-card.middle-contained,
-      ha-card.middle-blank {
+      :host > ha-card.middle-left,
+      :host > ha-card.middle-right,
+      :host > ha-card.middle-contained,
+      :host > ha-card.middle-blank {
         display: block !important;
         height: 100%;
         background-color: var(--lcars-background-color);
@@ -588,10 +581,10 @@
       :host(.middle-right) > *:not(style):not(card-mod):not(h1),
       :host(.middle-contained) > *:not(style):not(card-mod):not(h1),
       :host(.middle-blank) > *:not(style):not(card-mod):not(h1),
-      ha-card.middle-left > *:not(style):not(card-mod):not(h1),
-      ha-card.middle-right > *:not(style):not(card-mod):not(h1),
-      ha-card.middle-contained > *:not(style):not(card-mod):not(h1),
-      ha-card.middle-blank > *:not(style):not(card-mod):not(h1) {
+      :host > ha-card.middle-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-blank > *:not(style):not(card-mod):not(h1) {
         border-radius: 0px;
         background-color: var(--lcars-background-color);
         --lcars-primary-text: var(--lcars-background-text);
@@ -619,29 +612,29 @@
 
       :host(.middle-left),
       :host(.middle-contained),
-      ha-card.middle-left,
-      ha-card.middle-contained {
+      :host > ha-card.middle-left,
+      :host > ha-card.middle-contained {
         border-left-width: var(--lcars-vertical-border);
       }
 
       :host(.middle-left) > *:not(style):not(card-mod),
       :host(.middle-contained) > *:not(style):not(card-mod),
-      ha-card.middle-left > *:not(style):not(card-mod),
-      ha-card.middle-contained > *:not(style):not(card-mod) {
+      :host > ha-card.middle-left > *:not(style):not(card-mod),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod) {
         padding-left: 6px;
       }
 
       :host(.middle-right),
       :host(.middle-contained),
-      ha-card.middle-right,
-      ha-card.middle-contained {
+      :host > ha-card.middle-right,
+      :host > ha-card.middle-contained {
         border-right-width: var(--lcars-vertical-border);
       }
 
       :host(.middle-right) > *:not(style):not(card-mod),
       :host(.middle-contained) > *:not(style):not(card-mod),
-      ha-card.middle-right > *:not(style):not(card-mod),
-      ha-card.middle-contained > *:not(style):not(card-mod) {
+      :host > ha-card.middle-right > *:not(style):not(card-mod),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod) {
         padding-right: 6px;
       }
 
@@ -649,10 +642,10 @@
       :host(.footer-right),
       :host(.footer-contained),
       :host(.footer-open),
-      ha-card.footer-left,
-      ha-card.footer-right,
-      ha-card.footer-contained,
-      ha-card.footer-open {
+      :host > ha-card.footer-left,
+      :host > ha-card.footer-right,
+      :host > ha-card.footer-contained,
+      :host > ha-card.footer-open {
         display: block !important;
         height: 100%;
         padding: 0px;
@@ -668,10 +661,10 @@
       :host(.footer-right) > *:not(style):not(card-mod):not(h1),
       :host(.footer-contained) > *:not(style):not(card-mod):not(h1),
       :host(.footer-open) > *:not(style):not(card-mod):not(h1),
-      ha-card.footer-left > *:not(style):not(card-mod):not(h1),
-      ha-card.footer-right > *:not(style):not(card-mod):not(h1),
-      ha-card.footer-contained > *:not(style):not(card-mod):not(h1),
-      ha-card.footer-open > *:not(style):not(card-mod):not(h1) {
+      :host > ha-card.footer-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-open > *:not(style):not(card-mod):not(h1) {
         border-radius: 0px;
         background-color: var(--lcars-background-color);
         --lcars-primary-text: var(--lcars-background-text);
@@ -701,109 +694,96 @@
       :host(.footer-contained) > ha-card > ha-markdown,
       :host(.footer-open) > ha-markdown,
       :host(.footer-open) > ha-card > ha-markdown,
-      ha-card.footer-left > ha-markdown,
-      ha-card.footer-left > ha-card > ha-markdown,
-      ha-card.footer-right > ha-markdown,
-      ha-card.footer-right > ha-card > ha-markdown,
-      ha-card.footer-contained > ha-markdown,
-      ha-card.footer-contained > ha-card > ha-markdown,
-      ha-card.footer-open > ha-markdown,
-      ha-card.footer-open > ha-card > ha-markdown {
+      :host > ha-card.footer-left > ha-markdown,
+      :host > ha-card.footer-left > ha-card > ha-markdown,
+      :host > ha-card.footer-right > ha-markdown,
+      :host > ha-card.footer-right > ha-card > ha-markdown,
+      :host > ha-card.footer-contained > ha-markdown,
+      :host > ha-card.footer-contained > ha-card > ha-markdown,
+      :host > ha-card.footer-open > ha-markdown,
+      :host > ha-card.footer-open > ha-card > ha-markdown {
         padding-block: 0px;
       }
 
       :host(.footer-left),
       :host(.footer-contained),
-      ha-card.footer-left,
-      ha-card.footer-contained {
+      :host > ha-card.footer-left,
+      :host > ha-card.footer-contained {
         border-bottom-left-radius: var(--ha-card-border-radius) !important;
         border-left-width: var(--lcars-vertical-border);
       }
 
       :host(.footer-left) > *:not(style):not(card-mod),
       :host(.footer-contained) > *:not(style):not(card-mod),
-      ha-card.footer-left > *:not(style):not(card-mod),
-      ha-card.footer-contained > *:not(style):not(card-mod) {
+      :host > ha-card.footer-left > *:not(style):not(card-mod),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod) {
         border-bottom-left-radius: var(--lcars-inner-radius) !important;
         padding-left: 6px;
       }
 
       :host(.footer-right),
       :host(.footer-contained),
-      ha-card.footer-right,
-      ha-card.footer-contained {
+      :host > ha-card.footer-right,
+      :host > ha-card.footer-contained {
         border-bottom-right-radius: var(--ha-card-border-radius) !important;
         border-right-width: var(--lcars-vertical-border);
       }
 
       :host(.footer-right) > *:not(style):not(card-mod),
       :host(.footer-contained) > *:not(style):not(card-mod),
-      ha-card.footer-right > *:not(style):not(card-mod),
-      ha-card.footer-contained > *:not(style):not(card-mod) {
+      :host > ha-card.footer-right > *:not(style):not(card-mod),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod) {
         border-bottom-right-radius: var(--lcars-inner-radius) !important;
         padding-right: 6px;
       }
 
       :host(.button-small) > ha-card,
       :host(.button-small) > #aspect-ratio > ha-card,
-      :host(.button-small)ha-card,
       :host(.button-large) > ha-card,
       :host(.button-large) > #aspect-ratio > ha-card,
-      :host(.button-large)ha-card,
       :host(.button-lozenge-left) > ha-card,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-left)ha-card,
       :host(.button-lozenge-right) > ha-card,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-right)ha-card,
       :host(.button-bullet-left) > ha-card,
       :host(.button-bullet-left) > #aspect-ratio > ha-card,
-      :host(.button-bullet-left)ha-card,
       :host(.button-bullet-right) > ha-card,
       :host(.button-bullet-right) > #aspect-ratio > ha-card,
-      :host(.button-bullet-right)ha-card,
       :host(.button-capped-left) > ha-card,
       :host(.button-capped-left) > #aspect-ratio > ha-card,
-      :host(.button-capped-left)ha-card,
       :host(.button-capped-right) > ha-card,
       :host(.button-capped-right) > #aspect-ratio > ha-card,
-      :host(.button-capped-right)ha-card,
       :host(.button-barrel-left) > ha-card,
       :host(.button-barrel-left) > #aspect-ratio > ha-card,
-      :host(.button-barrel-left)ha-card,
       :host(.button-barrel-right) > ha-card,
       :host(.button-barrel-right) > #aspect-ratio > ha-card,
-      :host(.button-barrel-right)ha-card,
-      ha-card; .button-small > ha-card,
-      ha-card; .button-small > #aspect-ratio > ha-card,
-      ha-card; .button-smallha-card,
       ha-card.button-large > ha-card,
       ha-card.button-large > #aspect-ratio > ha-card,
-      ha-card.button-largeha-card,
+      ha-card.button-large,
       ha-card.button-lozenge-left > ha-card,
       ha-card.button-lozenge-left > #aspect-ratio > ha-card,
-      ha-card.button-lozenge-leftha-card,
+      ha-card.button-lozenge-left,
       ha-card.button-lozenge-right > ha-card,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card,
-      ha-card.button-lozenge-rightha-card,
+      ha-card.button-lozenge-right,
       ha-card.button-bullet-left > ha-card,
       ha-card.button-bullet-left > #aspect-ratio > ha-card,
-      ha-card.button-bullet-leftha-card,
+      ha-card.button-bullet-left,
       ha-card.button-bullet-right > ha-card,
       ha-card.button-bullet-right > #aspect-ratio > ha-card,
-      ha-card.button-bullet-rightha-card,
+      ha-card.button-bullet-right,
       ha-card.button-capped-left > ha-card,
       ha-card.button-capped-left > #aspect-ratio > ha-card,
-      ha-card.button-capped-leftha-card,
+      ha-card.button-capped-left,
       ha-card.button-capped-right > ha-card,
       ha-card.button-capped-right > #aspect-ratio > ha-card,
-      ha-card.button-capped-rightha-card,
+      ha-card.button-capped-right,
       ha-card.button-barrel-left > ha-card,
       ha-card.button-barrel-left > #aspect-ratio > ha-card,
-      ha-card.button-barrel-leftha-card,
+      ha-card.button-barrel-left,
       ha-card.button-barrel-right > ha-card,
       ha-card.button-barrel-right > #aspect-ratio > ha-card,
-      ha-card.button-barrel-rightha-card {
+      ha-card.button-barrel-right {
         background-color: var(--lcars-card-button-color);
         --lcars-primary-text: var(--lcars-card-button-text);
         --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
@@ -824,16 +804,11 @@
 
       :host(.button-bar-left) > ha-card,
       :host(.button-bar-left) > #aspect-ratio > ha-card,
-      :host(.button-bar-left)ha-card,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
-      ha-card; .button-bar-left > ha-card,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card,
-      ha-card; .button-bar-leftha-card,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         background-color: var(--lcars-card-button-color);
         --lcars-primary-text: var(--lcars-card-button-text);
         --state-icon-color: var(--lcars-primary-text);
@@ -842,10 +817,9 @@
 
       :host(.button-small) > ha-card,
       :host(.button-small) > #aspect-ratio > ha-card,
-      :host(.button-small)ha-card,
       ha-card.button-small > ha-card,
       ha-card.button-small > #aspect-ratio > ha-card,
-      ha-card.button-smallha-card {
+      ha-card.button-small {
         display: flex;
         border-radius: 0px !important;
         position: relative;
@@ -856,19 +830,17 @@
 
       :host(.button-small) > ha-card > .more-info,
       :host(.button-small) > #aspect-ratio > ha-card > .more-info,
-      :host(.button-small)ha-card > .more-info,
       ha-card.button-small > ha-card > .more-info,
       ha-card.button-small > #aspect-ratio > ha-card > .more-info,
-      ha-card.button-smallha-card > .more-info {
+      ha-card.button-small > .more-info {
         display: none;
       }
 
       :host(.button-small) > ha-card > .content > #controls,
       :host(.button-small) > #aspect-ratio > ha-card > .content > #controls,
-      :host(.button-small)ha-card > .content > #controls,
       ha-card.button-small > ha-card > .content > #controls,
       ha-card.button-small > #aspect-ratio > ha-card > .content > #controls,
-      ha-card.button-smallha-card > .content > #controls {
+      ha-card.button-small > .content > #controls {
         display: flex;
         place-content: flex-start center;
         position: relative;
@@ -877,10 +849,9 @@
 
       :host(.button-small) > ha-card > .content > #info,
       :host(.button-small) > #aspect-ratio > ha-card > .content > #info,
-      :host(.button-small)ha-card > .content > #info,
       ha-card.button-small > ha-card > .content > #info,
       ha-card.button-small > #aspect-ratio > ha-card > .content > #info,
-      ha-card.button-smallha-card > .content > #info {
+      ha-card.button-small > .content > #info {
         text-align: right;
         box-sizing: border-box;
         width: 100%;
@@ -891,10 +862,9 @@
 
       :host(.button-small) > ha-card > span,
       :host(.button-small) > #aspect-ratio > ha-card > span,
-      :host(.button-small)ha-card > span,
       ha-card.button-small > ha-card > span,
       ha-card.button-small > #aspect-ratio > ha-card > span,
-      ha-card.button-smallha-card > span {
+      ha-card.button-small > span {
         box-sizing: border-box;
         text-align: right;
         width: 100%;
@@ -906,10 +876,9 @@
 
       :host(.button-small) > ha-card > span.state,
       :host(.button-small) > #aspect-ratio > ha-card > span.state,
-      :host(.button-small)ha-card > span.state,
       ha-card.button-small > ha-card > span.state,
       ha-card.button-small > #aspect-ratio > ha-card > span.state,
-      ha-card.button-smallha-card > span.state {
+      ha-card.button-small > span.state {
         text-align: right;
         width: 100%;
         padding: 6px;
@@ -921,64 +890,51 @@
 
       :host(.button-lozenge-left) > ha-card,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-left)ha-card,
       :host(.button-lozenge-right) > ha-card,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-right)ha-card,
       :host(.button-bullet-left) > ha-card,
       :host(.button-bullet-left) > #aspect-ratio > ha-card,
-      :host(.button-bullet-left)ha-card,
       :host(.button-bullet-right) > ha-card,
       :host(.button-bullet-right) > #aspect-ratio > ha-card,
-      :host(.button-bullet-right)ha-card,
       :host(.button-capped-left) > ha-card,
       :host(.button-capped-left) > #aspect-ratio > ha-card,
-      :host(.button-capped-left)ha-card,
       :host(.button-capped-right) > ha-card,
       :host(.button-capped-right) > #aspect-ratio > ha-card,
-      :host(.button-capped-right)ha-card,
       :host(.button-barrel-left) > ha-card,
       :host(.button-barrel-left) > #aspect-ratio > ha-card,
-      :host(.button-barrel-left)ha-card,
       :host(.button-barrel-right) > ha-card,
       :host(.button-barrel-right) > #aspect-ratio > ha-card,
-      :host(.button-barrel-right)ha-card,
       :host(.button-bar-left) > ha-card,
       :host(.button-bar-left) > #aspect-ratio > ha-card,
-      :host(.button-bar-left)ha-card,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
-      ha-card; .button-lozenge-left > ha-card,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card,
-      ha-card; .button-lozenge-leftha-card,
       ha-card.button-lozenge-right > ha-card,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card,
-      ha-card.button-lozenge-rightha-card,
+      ha-card.button-lozenge-right,
       ha-card.button-bullet-left > ha-card,
       ha-card.button-bullet-left > #aspect-ratio > ha-card,
-      ha-card.button-bullet-leftha-card,
+      ha-card.button-bullet-left,
       ha-card.button-bullet-right > ha-card,
       ha-card.button-bullet-right > #aspect-ratio > ha-card,
-      ha-card.button-bullet-rightha-card,
+      ha-card.button-bullet-right,
       ha-card.button-capped-left > ha-card,
       ha-card.button-capped-left > #aspect-ratio > ha-card,
-      ha-card.button-capped-leftha-card,
+      ha-card.button-capped-left,
       ha-card.button-capped-right > ha-card,
       ha-card.button-capped-right > #aspect-ratio > ha-card,
-      ha-card.button-capped-rightha-card,
+      ha-card.button-capped-right,
       ha-card.button-barrel-left > ha-card,
       ha-card.button-barrel-left > #aspect-ratio > ha-card,
-      ha-card.button-barrel-leftha-card,
+      ha-card.button-barrel-left,
       ha-card.button-barrel-right > ha-card,
       ha-card.button-barrel-right > #aspect-ratio > ha-card,
-      ha-card.button-barrel-rightha-card,
+      ha-card.button-barrel-right,
       ha-card.button-bar-left > ha-card,
       ha-card.button-bar-left > #aspect-ratio > ha-card,
-      ha-card.button-bar-leftha-card,
+      ha-card.button-bar-left,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         min-height: 60px;
         display: flex;
         align-items: flex-end;
@@ -989,64 +945,51 @@
 
       :host(.button-lozenge-left) > ha-card > ha-state-icon,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-lozenge-left)ha-card > ha-state-icon,
       :host(.button-lozenge-right) > ha-card > ha-state-icon,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-lozenge-right)ha-card > ha-state-icon,
       :host(.button-bullet-left) > ha-card > ha-state-icon,
       :host(.button-bullet-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bullet-left)ha-card > ha-state-icon,
       :host(.button-bullet-right) > ha-card > ha-state-icon,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bullet-right)ha-card > ha-state-icon,
       :host(.button-capped-left) > ha-card > ha-state-icon,
       :host(.button-capped-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-capped-left)ha-card > ha-state-icon,
       :host(.button-capped-right) > ha-card > ha-state-icon,
       :host(.button-capped-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-capped-right)ha-card > ha-state-icon,
       :host(.button-barrel-left) > ha-card > ha-state-icon,
       :host(.button-barrel-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-barrel-left)ha-card > ha-state-icon,
       :host(.button-barrel-right) > ha-card > ha-state-icon,
       :host(.button-barrel-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-barrel-right)ha-card > ha-state-icon,
       :host(.button-bar-left) > ha-card > ha-state-icon,
       :host(.button-bar-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bar-left)ha-card > ha-state-icon,
       :host(.button-bar-right) > ha-card > ha-state-icon,
       :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bar-right)ha-card > ha-state-icon,
-      ha-card; .button-lozenge-left > ha-card > ha-state-icon,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card; .button-lozenge-leftha-card > ha-state-icon,
       ha-card.button-lozenge-right > ha-card > ha-state-icon,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-lozenge-rightha-card > ha-state-icon,
+      ha-card.button-lozenge-right > ha-state-icon,
       ha-card.button-bullet-left > ha-card > ha-state-icon,
       ha-card.button-bullet-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bullet-leftha-card > ha-state-icon,
+      ha-card.button-bullet-left > ha-state-icon,
       ha-card.button-bullet-right > ha-card > ha-state-icon,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bullet-rightha-card > ha-state-icon,
+      ha-card.button-bullet-right > ha-state-icon,
       ha-card.button-capped-left > ha-card > ha-state-icon,
       ha-card.button-capped-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-capped-leftha-card > ha-state-icon,
+      ha-card.button-capped-left > ha-state-icon,
       ha-card.button-capped-right > ha-card > ha-state-icon,
       ha-card.button-capped-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-capped-rightha-card > ha-state-icon,
+      ha-card.button-capped-right > ha-state-icon,
       ha-card.button-barrel-left > ha-card > ha-state-icon,
       ha-card.button-barrel-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-barrel-leftha-card > ha-state-icon,
+      ha-card.button-barrel-left > ha-state-icon,
       ha-card.button-barrel-right > ha-card > ha-state-icon,
       ha-card.button-barrel-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-barrel-rightha-card > ha-state-icon,
+      ha-card.button-barrel-right > ha-state-icon,
       ha-card.button-bar-left > ha-card > ha-state-icon,
       ha-card.button-bar-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bar-leftha-card > ha-state-icon,
+      ha-card.button-bar-left > ha-state-icon,
       ha-card.button-bar-right > ha-card > ha-state-icon,
       ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bar-rightha-card > ha-state-icon {
+      ha-card.button-bar-right > ha-state-icon {
         --mdc-icon-size: unset;
         background-color: var(--lcars-card-top-color);
         position: absolute;
@@ -1062,64 +1005,51 @@
 
       :host(.button-lozenge-left) > ha-card > span,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card > span,
-      :host(.button-lozenge-left)ha-card > span,
       :host(.button-lozenge-right) > ha-card > span,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
-      :host(.button-lozenge-right)ha-card > span,
       :host(.button-bullet-left) > ha-card > span,
       :host(.button-bullet-left) > #aspect-ratio > ha-card > span,
-      :host(.button-bullet-left)ha-card > span,
       :host(.button-bullet-right) > ha-card > span,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
-      :host(.button-bullet-right)ha-card > span,
       :host(.button-capped-left) > ha-card > span,
       :host(.button-capped-left) > #aspect-ratio > ha-card > span,
-      :host(.button-capped-left)ha-card > span,
       :host(.button-capped-right) > ha-card > span,
       :host(.button-capped-right) > #aspect-ratio > ha-card > span,
-      :host(.button-capped-right)ha-card > span,
       :host(.button-barrel-left) > ha-card > span,
       :host(.button-barrel-left) > #aspect-ratio > ha-card > span,
-      :host(.button-barrel-left)ha-card > span,
       :host(.button-barrel-right) > ha-card > span,
       :host(.button-barrel-right) > #aspect-ratio > ha-card > span,
-      :host(.button-barrel-right)ha-card > span,
       :host(.button-bar-left) > ha-card > span,
       :host(.button-bar-left) > #aspect-ratio > ha-card > span,
-      :host(.button-bar-left)ha-card > span,
       :host(.button-bar-right) > ha-card > span,
       :host(.button-bar-right) > #aspect-ratio > ha-card > span,
-      :host(.button-bar-right)ha-card > span,
-      ha-card; .button-lozenge-left > ha-card > span,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card > span,
-      ha-card; .button-lozenge-leftha-card > span,
       ha-card.button-lozenge-right > ha-card > span,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card > span,
-      ha-card.button-lozenge-rightha-card > span,
+      ha-card.button-lozenge-right > span,
       ha-card.button-bullet-left > ha-card > span,
       ha-card.button-bullet-left > #aspect-ratio > ha-card > span,
-      ha-card.button-bullet-leftha-card > span,
+      ha-card.button-bullet-left > span,
       ha-card.button-bullet-right > ha-card > span,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
-      ha-card.button-bullet-rightha-card > span,
+      ha-card.button-bullet-right > span,
       ha-card.button-capped-left > ha-card > span,
       ha-card.button-capped-left > #aspect-ratio > ha-card > span,
-      ha-card.button-capped-leftha-card > span,
+      ha-card.button-capped-left > span,
       ha-card.button-capped-right > ha-card > span,
       ha-card.button-capped-right > #aspect-ratio > ha-card > span,
-      ha-card.button-capped-rightha-card > span,
+      ha-card.button-capped-right > span,
       ha-card.button-barrel-left > ha-card > span,
       ha-card.button-barrel-left > #aspect-ratio > ha-card > span,
-      ha-card.button-barrel-leftha-card > span,
+      ha-card.button-barrel-left > span,
       ha-card.button-barrel-right > ha-card > span,
       ha-card.button-barrel-right > #aspect-ratio > ha-card > span,
-      ha-card.button-barrel-rightha-card > span,
+      ha-card.button-barrel-right > span,
       ha-card.button-bar-left > ha-card > span,
       ha-card.button-bar-left > #aspect-ratio > ha-card > span,
-      ha-card.button-bar-leftha-card > span,
+      ha-card.button-bar-left > span,
       ha-card.button-bar-right > ha-card > span,
       ha-card.button-bar-right > #aspect-ratio > ha-card > span,
-      ha-card.button-bar-rightha-card > span {
+      ha-card.button-bar-right > span {
         width: 100%;
         height: 100%;
         display: flex;
@@ -1131,128 +1061,102 @@
 
       :host(.button-lozenge-left) > ha-card > span.state,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-lozenge-left)ha-card > span.state,
       :host(.button-lozenge-right) > ha-card > span.state,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-lozenge-right)ha-card > span.state,
       :host(.button-bullet-left) > ha-card > span.state,
       :host(.button-bullet-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bullet-left)ha-card > span.state,
       :host(.button-bullet-right) > ha-card > span.state,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bullet-right)ha-card > span.state,
       :host(.button-capped-left) > ha-card > span.state,
       :host(.button-capped-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-capped-left)ha-card > span.state,
       :host(.button-capped-right) > ha-card > span.state,
       :host(.button-capped-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-capped-right)ha-card > span.state,
       :host(.button-barrel-left) > ha-card > span.state,
       :host(.button-barrel-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-barrel-left)ha-card > span.state,
       :host(.button-barrel-right) > ha-card > span.state,
       :host(.button-barrel-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-barrel-right)ha-card > span.state,
       :host(.button-bar-left) > ha-card > span.state,
       :host(.button-bar-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bar-left)ha-card > span.state,
       :host(.button-bar-right) > ha-card > span.state,
       :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bar-right)ha-card > span.state,
-      ha-card; .button-lozenge-left > ha-card > span.state,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card > span.state,
-      ha-card; .button-lozenge-leftha-card > span.state,
       ha-card.button-lozenge-right > ha-card > span.state,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-lozenge-rightha-card > span.state,
+      ha-card.button-lozenge-right > span.state,
       ha-card.button-bullet-left > ha-card > span.state,
       ha-card.button-bullet-left > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bullet-leftha-card > span.state,
+      ha-card.button-bullet-left > span.state,
       ha-card.button-bullet-right > ha-card > span.state,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bullet-rightha-card > span.state,
+      ha-card.button-bullet-right > span.state,
       ha-card.button-capped-left > ha-card > span.state,
       ha-card.button-capped-left > #aspect-ratio > ha-card > span.state,
-      ha-card.button-capped-leftha-card > span.state,
+      ha-card.button-capped-left > span.state,
       ha-card.button-capped-right > ha-card > span.state,
       ha-card.button-capped-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-capped-rightha-card > span.state,
+      ha-card.button-capped-right > span.state,
       ha-card.button-barrel-left > ha-card > span.state,
       ha-card.button-barrel-left > #aspect-ratio > ha-card > span.state,
-      ha-card.button-barrel-leftha-card > span.state,
+      ha-card.button-barrel-left > span.state,
       ha-card.button-barrel-right > ha-card > span.state,
       ha-card.button-barrel-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-barrel-rightha-card > span.state,
+      ha-card.button-barrel-right > span.state,
       ha-card.button-bar-left > ha-card > span.state,
       ha-card.button-bar-left > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bar-leftha-card > span.state,
+      ha-card.button-bar-left > span.state,
       ha-card.button-bar-right > ha-card > span.state,
       ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bar-rightha-card > span.state {
+      ha-card.button-bar-right > span.state {
         align-items: center;
         color: var(--lcars-card-button-text);
       }
 
       :host(.button-lozenge-left) > ha-card#container > #slider,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-lozenge-left)ha-card#container > #slider,
       :host(.button-lozenge-right) > ha-card#container > #slider,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-lozenge-right)ha-card#container > #slider,
       :host(.button-bullet-left) > ha-card#container > #slider,
       :host(.button-bullet-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bullet-left)ha-card#container > #slider,
       :host(.button-bullet-right) > ha-card#container > #slider,
       :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bullet-right)ha-card#container > #slider,
       :host(.button-capped-left) > ha-card#container > #slider,
       :host(.button-capped-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-capped-left)ha-card#container > #slider,
       :host(.button-capped-right) > ha-card#container > #slider,
       :host(.button-capped-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-capped-right)ha-card#container > #slider,
       :host(.button-barrel-left) > ha-card#container > #slider,
       :host(.button-barrel-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-barrel-left)ha-card#container > #slider,
       :host(.button-barrel-right) > ha-card#container > #slider,
       :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-barrel-right)ha-card#container > #slider,
       :host(.button-bar-left) > ha-card#container > #slider,
       :host(.button-bar-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bar-left)ha-card#container > #slider,
       :host(.button-bar-right) > ha-card#container > #slider,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bar-right)ha-card#container > #slider,
-      ha-card; .button-lozenge-left > ha-card#container > #slider,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card; .button-lozenge-leftha-card#container > #slider,
       ha-card.button-lozenge-right > ha-card#container > #slider,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-lozenge-rightha-card#container > #slider,
+      ha-card.button-lozenge-right#container > #slider,
       ha-card.button-bullet-left > ha-card#container > #slider,
       ha-card.button-bullet-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bullet-leftha-card#container > #slider,
+      ha-card.button-bullet-left#container > #slider,
       ha-card.button-bullet-right > ha-card#container > #slider,
       ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bullet-rightha-card#container > #slider,
+      ha-card.button-bullet-right#container > #slider,
       ha-card.button-capped-left > ha-card#container > #slider,
       ha-card.button-capped-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-capped-leftha-card#container > #slider,
+      ha-card.button-capped-left#container > #slider,
       ha-card.button-capped-right > ha-card#container > #slider,
       ha-card.button-capped-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-capped-rightha-card#container > #slider,
+      ha-card.button-capped-right#container > #slider,
       ha-card.button-barrel-left > ha-card#container > #slider,
       ha-card.button-barrel-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-barrel-leftha-card#container > #slider,
+      ha-card.button-barrel-left#container > #slider,
       ha-card.button-barrel-right > ha-card#container > #slider,
       ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-barrel-rightha-card#container > #slider,
+      ha-card.button-barrel-right#container > #slider,
       ha-card.button-bar-left > ha-card#container > #slider,
       ha-card.button-bar-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bar-leftha-card#container > #slider,
+      ha-card.button-bar-left#container > #slider,
       ha-card.button-bar-right > ha-card#container > #slider,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bar-rightha-card#container > #slider {
+      ha-card.button-bar-right#container > #slider {
         right: 0;
         left: calc(var(--lcars-vertical-border) + 6px);
         background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
@@ -1260,64 +1164,51 @@
 
       :host(.button-lozenge-left) > ha-card#container > #content,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-lozenge-left)ha-card#container > #content,
       :host(.button-lozenge-right) > ha-card#container > #content,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-lozenge-right)ha-card#container > #content,
       :host(.button-bullet-left) > ha-card#container > #content,
       :host(.button-bullet-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bullet-left)ha-card#container > #content,
       :host(.button-bullet-right) > ha-card#container > #content,
       :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bullet-right)ha-card#container > #content,
       :host(.button-capped-left) > ha-card#container > #content,
       :host(.button-capped-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-capped-left)ha-card#container > #content,
       :host(.button-capped-right) > ha-card#container > #content,
       :host(.button-capped-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-capped-right)ha-card#container > #content,
       :host(.button-barrel-left) > ha-card#container > #content,
       :host(.button-barrel-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-barrel-left)ha-card#container > #content,
       :host(.button-barrel-right) > ha-card#container > #content,
       :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-barrel-right)ha-card#container > #content,
       :host(.button-bar-left) > ha-card#container > #content,
       :host(.button-bar-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bar-left)ha-card#container > #content,
       :host(.button-bar-right) > ha-card#container > #content,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bar-right)ha-card#container > #content,
-      ha-card; .button-lozenge-left > ha-card#container > #content,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card#container > #content,
-      ha-card; .button-lozenge-leftha-card#container > #content,
       ha-card.button-lozenge-right > ha-card#container > #content,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-lozenge-rightha-card#container > #content,
+      ha-card.button-lozenge-right#container > #content,
       ha-card.button-bullet-left > ha-card#container > #content,
       ha-card.button-bullet-left > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bullet-leftha-card#container > #content,
+      ha-card.button-bullet-left#container > #content,
       ha-card.button-bullet-right > ha-card#container > #content,
       ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bullet-rightha-card#container > #content,
+      ha-card.button-bullet-right#container > #content,
       ha-card.button-capped-left > ha-card#container > #content,
       ha-card.button-capped-left > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-capped-leftha-card#container > #content,
+      ha-card.button-capped-left#container > #content,
       ha-card.button-capped-right > ha-card#container > #content,
       ha-card.button-capped-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-capped-rightha-card#container > #content,
+      ha-card.button-capped-right#container > #content,
       ha-card.button-barrel-left > ha-card#container > #content,
       ha-card.button-barrel-left > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-barrel-leftha-card#container > #content,
+      ha-card.button-barrel-left#container > #content,
       ha-card.button-barrel-right > ha-card#container > #content,
       ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-barrel-rightha-card#container > #content,
+      ha-card.button-barrel-right#container > #content,
       ha-card.button-bar-left > ha-card#container > #content,
       ha-card.button-bar-left > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bar-leftha-card#container > #content,
+      ha-card.button-bar-left#container > #content,
       ha-card.button-bar-right > ha-card#container > #content,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bar-rightha-card#container > #content {
+      ha-card.button-bar-right#container > #content {
         padding-left: calc(var(--lcars-vertical-border) + 18px);
         justify-content: right;
       }
@@ -1325,70 +1216,54 @@
       :host(.button-lozenge-right) > ha-card#container,
       :host(.button-lozenge-right) > ha-card,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-right)ha-card,
       :host(.button-bullet-right) > ha-card#container,
       :host(.button-bullet-right) > ha-card,
       :host(.button-bullet-right) > #aspect-ratio > ha-card,
-      :host(.button-bullet-right)ha-card,
       :host(.button-capped-right) > ha-card#container,
       :host(.button-capped-right) > ha-card,
       :host(.button-capped-right) > #aspect-ratio > ha-card,
-      :host(.button-capped-right)ha-card,
       :host(.button-barrel-right) > ha-card#container,
       :host(.button-barrel-right) > ha-card,
       :host(.button-barrel-right) > #aspect-ratio > ha-card,
-      :host(.button-barrel-right)ha-card,
-      ha-card; .button-lozenge-right > ha-card#container,
-      ha-card; .button-lozenge-right > ha-card,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card,
-      ha-card; .button-lozenge-rightha-card,
       ha-card.button-bullet-right > ha-card#container,
       ha-card.button-bullet-right > ha-card,
       ha-card.button-bullet-right > #aspect-ratio > ha-card,
-      ha-card.button-bullet-rightha-card,
+      ha-card.button-bullet-right,
       ha-card.button-capped-right > ha-card#container,
       ha-card.button-capped-right > ha-card,
       ha-card.button-capped-right > #aspect-ratio > ha-card,
-      ha-card.button-capped-rightha-card,
+      ha-card.button-capped-right,
       ha-card.button-barrel-right > ha-card#container,
       ha-card.button-barrel-right > ha-card,
       ha-card.button-barrel-right > #aspect-ratio > ha-card,
-      ha-card.button-barrel-rightha-card {
+      ha-card.button-barrel-right {
         align-items: flex-start;
       }
 
       :host(.button-lozenge-right) > ha-card#container > ha-state-icon,
       :host(.button-lozenge-right) > ha-card > ha-state-icon,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-lozenge-right)ha-card > ha-state-icon,
       :host(.button-bullet-right) > ha-card#container > ha-state-icon,
       :host(.button-bullet-right) > ha-card > ha-state-icon,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bullet-right)ha-card > ha-state-icon,
       :host(.button-capped-right) > ha-card#container > ha-state-icon,
       :host(.button-capped-right) > ha-card > ha-state-icon,
       :host(.button-capped-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-capped-right)ha-card > ha-state-icon,
       :host(.button-barrel-right) > ha-card#container > ha-state-icon,
       :host(.button-barrel-right) > ha-card > ha-state-icon,
       :host(.button-barrel-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-barrel-right)ha-card > ha-state-icon,
-      ha-card; .button-lozenge-right > ha-card#container > ha-state-icon,
-      ha-card; .button-lozenge-right > ha-card > ha-state-icon,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card; .button-lozenge-rightha-card > ha-state-icon,
       ha-card.button-bullet-right > ha-card#container > ha-state-icon,
       ha-card.button-bullet-right > ha-card > ha-state-icon,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bullet-rightha-card > ha-state-icon,
+      ha-card.button-bullet-right > ha-state-icon,
       ha-card.button-capped-right > ha-card#container > ha-state-icon,
       ha-card.button-capped-right > ha-card > ha-state-icon,
       ha-card.button-capped-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-capped-rightha-card > ha-state-icon,
+      ha-card.button-capped-right > ha-state-icon,
       ha-card.button-barrel-right > ha-card#container > ha-state-icon,
       ha-card.button-barrel-right > ha-card > ha-state-icon,
       ha-card.button-barrel-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-barrel-rightha-card > ha-state-icon {
+      ha-card.button-barrel-right > ha-state-icon {
         left: auto;
         right: 0;
         border-right: 0px;
@@ -1398,35 +1273,27 @@
       :host(.button-lozenge-right) > ha-card#container > span,
       :host(.button-lozenge-right) > ha-card > span,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
-      :host(.button-lozenge-right)ha-card > span,
       :host(.button-bullet-right) > ha-card#container > span,
       :host(.button-bullet-right) > ha-card > span,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
-      :host(.button-bullet-right)ha-card > span,
       :host(.button-capped-right) > ha-card#container > span,
       :host(.button-capped-right) > ha-card > span,
       :host(.button-capped-right) > #aspect-ratio > ha-card > span,
-      :host(.button-capped-right)ha-card > span,
       :host(.button-barrel-right) > ha-card#container > span,
       :host(.button-barrel-right) > ha-card > span,
       :host(.button-barrel-right) > #aspect-ratio > ha-card > span,
-      :host(.button-barrel-right)ha-card > span,
-      ha-card; .button-lozenge-right > ha-card#container > span,
-      ha-card; .button-lozenge-right > ha-card > span,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card > span,
-      ha-card; .button-lozenge-rightha-card > span,
       ha-card.button-bullet-right > ha-card#container > span,
       ha-card.button-bullet-right > ha-card > span,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
-      ha-card.button-bullet-rightha-card > span,
+      ha-card.button-bullet-right > span,
       ha-card.button-capped-right > ha-card#container > span,
       ha-card.button-capped-right > ha-card > span,
       ha-card.button-capped-right > #aspect-ratio > ha-card > span,
-      ha-card.button-capped-rightha-card > span,
+      ha-card.button-capped-right > span,
       ha-card.button-barrel-right > ha-card#container > span,
       ha-card.button-barrel-right > ha-card > span,
       ha-card.button-barrel-right > #aspect-ratio > ha-card > span,
-      ha-card.button-barrel-rightha-card > span {
+      ha-card.button-barrel-right > span {
         justify-content: flex-start;
         left: var(--lcars-vertical-border);
         padding-inline: 6px;
@@ -1435,35 +1302,27 @@
       :host(.button-lozenge-right) > ha-card#container > #slider,
       :host(.button-lozenge-right) > ha-card#container > #slider,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-lozenge-right)ha-card#container > #slider,
       :host(.button-bullet-right) > ha-card#container > #slider,
       :host(.button-bullet-right) > ha-card#container > #slider,
       :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bullet-right)ha-card#container > #slider,
       :host(.button-capped-right) > ha-card#container > #slider,
       :host(.button-capped-right) > ha-card#container > #slider,
       :host(.button-capped-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-capped-right)ha-card#container > #slider,
       :host(.button-barrel-right) > ha-card#container > #slider,
       :host(.button-barrel-right) > ha-card#container > #slider,
       :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-barrel-right)ha-card#container > #slider,
-      ha-card; .button-lozenge-right > ha-card#container > #slider,
-      ha-card; .button-lozenge-right > ha-card#container > #slider,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card; .button-lozenge-rightha-card#container > #slider,
       ha-card.button-bullet-right > ha-card#container > #slider,
       ha-card.button-bullet-right > ha-card#container > #slider,
       ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bullet-rightha-card#container > #slider,
+      ha-card.button-bullet-right#container > #slider,
       ha-card.button-capped-right > ha-card#container > #slider,
       ha-card.button-capped-right > ha-card#container > #slider,
       ha-card.button-capped-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-capped-rightha-card#container > #slider,
+      ha-card.button-capped-right#container > #slider,
       ha-card.button-barrel-right > ha-card#container > #slider,
       ha-card.button-barrel-right > ha-card#container > #slider,
       ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-barrel-rightha-card#container > #slider {
+      ha-card.button-barrel-right#container > #slider {
         right: calc(var(--lcars-vertical-border) + 6px);
         left: 0;
         background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
@@ -1472,35 +1331,27 @@
       :host(.button-lozenge-right) > ha-card#container > #content,
       :host(.button-lozenge-right) > ha-card#container > #content,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-lozenge-right)ha-card#container > #content,
       :host(.button-bullet-right) > ha-card#container > #content,
       :host(.button-bullet-right) > ha-card#container > #content,
       :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bullet-right)ha-card#container > #content,
       :host(.button-capped-right) > ha-card#container > #content,
       :host(.button-capped-right) > ha-card#container > #content,
       :host(.button-capped-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-capped-right)ha-card#container > #content,
       :host(.button-barrel-right) > ha-card#container > #content,
       :host(.button-barrel-right) > ha-card#container > #content,
       :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-barrel-right)ha-card#container > #content,
-      ha-card; .button-lozenge-right > ha-card#container > #content,
-      ha-card; .button-lozenge-right > ha-card#container > #content,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card#container > #content,
-      ha-card; .button-lozenge-rightha-card#container > #content,
       ha-card.button-bullet-right > ha-card#container > #content,
       ha-card.button-bullet-right > ha-card#container > #content,
       ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bullet-rightha-card#container > #content,
+      ha-card.button-bullet-right#container > #content,
       ha-card.button-capped-right > ha-card#container > #content,
       ha-card.button-capped-right > ha-card#container > #content,
       ha-card.button-capped-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-capped-rightha-card#container > #content,
+      ha-card.button-capped-right#container > #content,
       ha-card.button-barrel-right > ha-card#container > #content,
       ha-card.button-barrel-right > ha-card#container > #content,
       ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-barrel-rightha-card#container > #content {
+      ha-card.button-barrel-right#container > #content {
         padding-left: var(--ha-card-border-radius);
         padding-right: 0px;
         justify-content: left;
@@ -1509,51 +1360,41 @@
       :host(.button-lozenge-left) > ha-card#container,
       :host(.button-lozenge-left) > ha-card,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-left)ha-card,
       :host(.button-lozenge-right) > ha-card#container,
       :host(.button-lozenge-right) > ha-card,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-right)ha-card,
       :host(.button-bullet-left) > ha-card#container,
       :host(.button-bullet-left) > ha-card,
       :host(.button-bullet-left) > #aspect-ratio > ha-card,
-      :host(.button-bullet-left)ha-card,
       :host(.button-capped-right) > ha-card#container,
       :host(.button-capped-right) > ha-card,
       :host(.button-capped-right) > #aspect-ratio > ha-card,
-      :host(.button-capped-right)ha-card,
       :host(.button-bar-left) > ha-card#container,
       :host(.button-bar-left) > ha-card,
       :host(.button-bar-left) > #aspect-ratio > ha-card,
-      :host(.button-bar-left)ha-card,
       :host(.button-bar-right) > ha-card#container,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
-      ha-card; .button-lozenge-left > ha-card#container,
-      ha-card; .button-lozenge-left > ha-card,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card,
-      ha-card; .button-lozenge-leftha-card,
       ha-card.button-bullet-left > ha-card#container,
       ha-card.button-bullet-left > ha-card,
       ha-card.button-bullet-left > #aspect-ratio > ha-card,
-      ha-card.button-bullet-leftha-card,
+      ha-card.button-bullet-left,
       ha-card.button-bar-left > ha-card#container,
       ha-card.button-bar-left > ha-card,
       ha-card.button-bar-left > #aspect-ratio > ha-card,
-      ha-card.button-bar-leftha-card,
+      ha-card.button-bar-left,
       ha-card.button-lozenge-right > ha-card#container,
       ha-card.button-lozenge-right > ha-card,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card,
-      ha-card.button-lozenge-rightha-card,
+      ha-card.button-lozenge-right,
       ha-card.button-capped-right > ha-card#container,
       ha-card.button-capped-right > ha-card,
       ha-card.button-capped-right > #aspect-ratio > ha-card,
-      ha-card.button-capped-rightha-card,
+      ha-card.button-capped-right,
       ha-card.button-bar-right > ha-card#container,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         border-top-right-radius: var(--ha-card-border-radius);
         border-bottom-right-radius: var(--ha-card-border-radius);
       }
@@ -1561,51 +1402,41 @@
       :host(.button-lozenge-left) > ha-card#container,
       :host(.button-lozenge-left) > ha-card,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-left)ha-card,
       :host(.button-lozenge-right) > ha-card#container,
       :host(.button-lozenge-right) > ha-card,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card,
-      :host(.button-lozenge-right)ha-card,
       :host(.button-bullet-right) > ha-card#container,
       :host(.button-bullet-right) > ha-card,
       :host(.button-bullet-right) > #aspect-ratio > ha-card,
-      :host(.button-bullet-right)ha-card,
       :host(.button-capped-left) > ha-card#container,
       :host(.button-capped-left) > ha-card,
       :host(.button-capped-left) > #aspect-ratio > ha-card,
-      :host(.button-capped-left)ha-card,
       :host(.button-bar-left) > ha-card#container,
       :host(.button-bar-left) > ha-card,
       :host(.button-bar-left) > #aspect-ratio > ha-card,
-      :host(.button-bar-left)ha-card,
       :host(.button-bar-right) > ha-card#container,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
-      ha-card; .button-lozenge-left > ha-card#container,
-      ha-card; .button-lozenge-left > ha-card,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card,
-      ha-card; .button-lozenge-leftha-card,
       ha-card.button-capped-left > ha-card#container,
       ha-card.button-capped-left > ha-card,
       ha-card.button-capped-left > #aspect-ratio > ha-card,
-      ha-card.button-capped-leftha-card,
+      ha-card.button-capped-left,
       ha-card.button-bar-left > ha-card#container,
       ha-card.button-bar-left > ha-card,
       ha-card.button-bar-left > #aspect-ratio > ha-card,
-      ha-card.button-bar-leftha-card,
+      ha-card.button-bar-left,
       ha-card.button-lozenge-right > ha-card#container,
       ha-card.button-lozenge-right > ha-card,
       ha-card.button-lozenge-right > #aspect-ratio > ha-card,
-      ha-card.button-lozenge-rightha-card,
+      ha-card.button-lozenge-right,
       ha-card.button-bullet-right > ha-card#container,
       ha-card.button-bullet-right > ha-card,
       ha-card.button-bullet-right > #aspect-ratio > ha-card,
-      ha-card.button-bullet-rightha-card,
+      ha-card.button-bullet-right,
       ha-card.button-bar-right > ha-card#container,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         border-top-left-radius: var(--ha-card-border-radius);
         border-bottom-left-radius: var(--ha-card-border-radius);
       }
@@ -1613,57 +1444,39 @@
       :host(.button-lozenge-left) > ha-card#container > span,
       :host(.button-lozenge-left) > ha-card > span,
       :host(.button-lozenge-left) > #aspect-ratio > ha-card > span,
-      :host(.button-lozenge-left)ha-card > span,
       :host(.button-bullet-left) > ha-card#container > span,
       :host(.button-bullet-left) > ha-card > span,
       :host(.button-bullet-left) > #aspect-ratio > ha-card > span,
-      :host(.button-bullet-left)ha-card > span,
-      ha-card; .button-lozenge-left > ha-card#container > span,
-      ha-card; .button-lozenge-left > ha-card > span,
-      ha-card; .button-lozenge-left > #aspect-ratio > ha-card > span,
-      ha-card; .button-lozenge-leftha-card > span,
       ha-card.button-bullet-left > ha-card#container > span,
       ha-card.button-bullet-left > ha-card > span,
       ha-card.button-bullet-left > #aspect-ratio > ha-card > span,
-      ha-card.button-bullet-leftha-card > span {
+      ha-card.button-bullet-left > span {
         padding-right: var(--ha-card-border-radius);
       }
 
       :host(.button-lozenge-right) > ha-card#container > span,
       :host(.button-lozenge-right) > ha-card > span,
       :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
-      :host(.button-lozenge-right)ha-card > span,
       :host(.button-bullet-right) > ha-card#container > span,
       :host(.button-bullet-right) > ha-card > span,
       :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
-      :host(.button-bullet-right)ha-card > span,
-      ha-card; .button-lozenge-right > ha-card#container > span,
-      ha-card; .button-lozenge-right > ha-card > span,
-      ha-card; .button-lozenge-right > #aspect-ratio > ha-card > span,
-      ha-card; .button-lozenge-rightha-card > span,
       ha-card.button-bullet-right > ha-card#container > span,
       ha-card.button-bullet-right > ha-card > span,
       ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
-      ha-card.button-bullet-rightha-card > span {
+      ha-card.button-bullet-right > span {
         padding-left: var(--ha-card-border-radius);
       }
 
       :host(.button-bar-left) > ha-card#container,
       :host(.button-bar-left) > ha-card,
       :host(.button-bar-left) > #aspect-ratio > ha-card,
-      :host(.button-bar-left)ha-card,
       :host(.button-bar-right) > ha-card#container,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
-      ha-card; .button-bar-left > ha-card#container,
-      ha-card; .button-bar-left > ha-card,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card,
-      ha-card; .button-bar-leftha-card,
       ha-card.button-bar-right > ha-card#container,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         line-height: 60px;
         font-size: 60px;
         padding-left: var(--lcars-vertical-border);
@@ -1674,19 +1487,13 @@
       :host(.button-bar-left) > ha-card#container > span,
       :host(.button-bar-left) > ha-card > span,
       :host(.button-bar-left) > #aspect-ratio > ha-card > span,
-      :host(.button-bar-left)ha-card > span,
       :host(.button-bar-right) > ha-card#container > span,
       :host(.button-bar-right) > ha-card > span,
       :host(.button-bar-right) > #aspect-ratio > ha-card > span,
-      :host(.button-bar-right)ha-card > span,
-      ha-card; .button-bar-left > ha-card#container > span,
-      ha-card; .button-bar-left > ha-card > span,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card > span,
-      ha-card; .button-bar-leftha-card > span,
       ha-card.button-bar-right > ha-card#container > span,
       ha-card.button-bar-right > ha-card > span,
       ha-card.button-bar-right > #aspect-ratio > ha-card > span,
-      ha-card.button-bar-rightha-card > span {
+      ha-card.button-bar-right > span {
         width: fit-content;
         padding: 0px;
       }
@@ -1694,19 +1501,13 @@
       :host(.button-bar-left) > ha-card#container > span.state,
       :host(.button-bar-left) > ha-card > span.state,
       :host(.button-bar-left) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bar-left)ha-card > span.state,
       :host(.button-bar-right) > ha-card#container > span.state,
       :host(.button-bar-right) > ha-card > span.state,
       :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bar-right)ha-card > span.state,
-      ha-card; .button-bar-left > ha-card#container > span.state,
-      ha-card; .button-bar-left > ha-card > span.state,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card > span.state,
-      ha-card; .button-bar-leftha-card > span.state,
       ha-card.button-bar-right > ha-card#container > span.state,
       ha-card.button-bar-right > ha-card > span.state,
       ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bar-rightha-card > span.state {
+      ha-card.button-bar-right > span.state {
         padding-right: var(--ha-card-border-radius);
         height: 100%;
       }
@@ -1714,19 +1515,13 @@
       :host(.button-bar-left) > ha-card#container > span:not(.state),
       :host(.button-bar-left) > ha-card > span:not(.state),
       :host(.button-bar-left) > #aspect-ratio > ha-card > span:not(.state),
-      :host(.button-bar-left)ha-card > span:not(.state),
       :host(.button-bar-right) > ha-card#container > span:not(.state),
       :host(.button-bar-right) > ha-card > span:not(.state),
       :host(.button-bar-right) > #aspect-ratio > ha-card > span:not(.state),
-      :host(.button-bar-right)ha-card > span:not(.state),
-      ha-card; .button-bar-left > ha-card#container > span:not(.state),
-      ha-card; .button-bar-left > ha-card > span:not(.state),
-      ha-card; .button-bar-left > #aspect-ratio > ha-card > span:not(.state),
-      ha-card; .button-bar-leftha-card > span:not(.state),
       ha-card.button-bar-right > ha-card#container > span:not(.state),
       ha-card.button-bar-right > ha-card > span:not(.state),
       ha-card.button-bar-right > #aspect-ratio > ha-card > span:not(.state),
-      ha-card.button-bar-rightha-card > span:not(.state) {
+      ha-card.button-bar-right > span:not(.state) {
         color: var(--lcars-background-text);
         height: 100%;
         background-color: var(--lcars-background-color);
@@ -1738,38 +1533,26 @@
       :host(.button-bar-left) > ha-card#container > ha-state-icon,
       :host(.button-bar-left) > ha-card > ha-state-icon,
       :host(.button-bar-left) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bar-left)ha-card > ha-state-icon,
       :host(.button-bar-right) > ha-card#container > ha-state-icon,
       :host(.button-bar-right) > ha-card > ha-state-icon,
       :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bar-right)ha-card > ha-state-icon,
-      ha-card; .button-bar-left > ha-card#container > ha-state-icon,
-      ha-card; .button-bar-left > ha-card > ha-state-icon,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card; .button-bar-leftha-card > ha-state-icon,
       ha-card.button-bar-right > ha-card#container > ha-state-icon,
       ha-card.button-bar-right > ha-card > ha-state-icon,
       ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bar-rightha-card > ha-state-icon {
+      ha-card.button-bar-right > ha-state-icon {
         font-size: 0;
       }
 
       :host(.button-bar-left) > ha-card#container > #slider,
       :host(.button-bar-left) > ha-card#container > #slider,
       :host(.button-bar-left) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bar-left)ha-card#container > #slider,
       :host(.button-bar-right) > ha-card#container > #slider,
       :host(.button-bar-right) > ha-card#container > #slider,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bar-right)ha-card#container > #slider,
-      ha-card; .button-bar-left > ha-card#container > #slider,
-      ha-card; .button-bar-left > ha-card#container > #slider,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card#container > #slider,
-      ha-card; .button-bar-leftha-card#container > #slider,
       ha-card.button-bar-right > ha-card#container > #slider,
       ha-card.button-bar-right > ha-card#container > #slider,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bar-rightha-card#container > #slider {
+      ha-card.button-bar-right#container > #slider {
         right: 0;
         left: calc(var(--lcars-vertical-border) + 6px);
         background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
@@ -1778,19 +1561,13 @@
       :host(.button-bar-left) > ha-card#container > #content,
       :host(.button-bar-left) > ha-card#container > #content,
       :host(.button-bar-left) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bar-left)ha-card#container > #content,
       :host(.button-bar-right) > ha-card#container > #content,
       :host(.button-bar-right) > ha-card#container > #content,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bar-right)ha-card#container > #content,
-      ha-card; .button-bar-left > ha-card#container > #content,
-      ha-card; .button-bar-left > ha-card#container > #content,
-      ha-card; .button-bar-left > #aspect-ratio > ha-card#container > #content,
-      ha-card; .button-bar-leftha-card#container > #content,
       ha-card.button-bar-right > ha-card#container > #content,
       ha-card.button-bar-right > ha-card#container > #content,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bar-rightha-card#container > #content {
+      ha-card.button-bar-right#container > #content {
         position: relative;
         padding-right: var(--ha-card-border-radius);
         padding-left: 18px;
@@ -1801,11 +1578,10 @@
       :host(.button-bar-right) > ha-card#container,
       :host(.button-bar-right) > ha-card,
       :host(.button-bar-right) > #aspect-ratio > ha-card,
-      :host(.button-bar-right)ha-card,
       ha-card.button-bar-right > ha-card#container,
       ha-card.button-bar-right > ha-card,
       ha-card.button-bar-right > #aspect-ratio > ha-card,
-      ha-card.button-bar-rightha-card {
+      ha-card.button-bar-right {
         flex-direction: row-reverse;
         padding-left: 0;
         padding-right: var(--lcars-vertical-border);
@@ -1814,11 +1590,10 @@
       :host(.button-bar-right) > ha-card#container > span.state,
       :host(.button-bar-right) > ha-card > span.state,
       :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
-      :host(.button-bar-right)ha-card > span.state,
       ha-card.button-bar-right > ha-card#container > span.state,
       ha-card.button-bar-right > ha-card > span.state,
       ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
-      ha-card.button-bar-rightha-card > span.state {
+      ha-card.button-bar-right > span.state {
         padding-left: var(--ha-card-border-radius);
         padding-right: 0;
       }
@@ -1826,11 +1601,10 @@
       :host(.button-bar-right) > ha-card#container > ha-state-icon,
       :host(.button-bar-right) > ha-card > ha-state-icon,
       :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
-      :host(.button-bar-right)ha-card > ha-state-icon,
       ha-card.button-bar-right > ha-card#container > ha-state-icon,
       ha-card.button-bar-right > ha-card > ha-state-icon,
       ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
-      ha-card.button-bar-rightha-card > ha-state-icon {
+      ha-card.button-bar-right > ha-state-icon {
         left: auto;
         right: 0;
         border-right: 0px;
@@ -1840,11 +1614,10 @@
       :host(.button-bar-right) > ha-card#container > #slider,
       :host(.button-bar-right) > ha-card#container > #slider,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
-      :host(.button-bar-right)ha-card#container > #slider,
       ha-card.button-bar-right > ha-card#container > #slider,
       ha-card.button-bar-right > ha-card#container > #slider,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
-      ha-card.button-bar-rightha-card#container > #slider {
+      ha-card.button-bar-right#container > #slider {
         right: calc(var(--lcars-vertical-border) + 6px);
         left: 0;
         background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
@@ -1853,11 +1626,10 @@
       :host(.button-bar-right) > ha-card#container > #content,
       :host(.button-bar-right) > ha-card#container > #content,
       :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
-      :host(.button-bar-right)ha-card#container > #content,
       ha-card.button-bar-right > ha-card#container > #content,
       ha-card.button-bar-right > ha-card#container > #content,
       ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
-      ha-card.button-bar-rightha-card#container > #content {
+      ha-card.button-bar-right#container > #content {
         padding-left: var(--ha-card-border-radius);
         padding-right: 18px;
         justify-content: right;
@@ -1867,10 +1639,10 @@
       :host(.bar-right),
       :host(.bar-large-left),
       :host(.bar-large-right),
-      ha-card.bar-left,
-      ha-card.bar-large-left:not(div > *),
-      ha-card.bar-right,
-      ha-card.bar-large-right:not(div > *) {
+      :host > ha-card.bar-left,
+      :host > ha-card.bar-large-left,
+      :host > ha-card.bar-right,
+      :host > ha-card.bar-large-right {
         background-color: var(--lcars-card-top-color);
         --lcars-primary-text: var(--lcars-card-top-text);
         border-radius: 9999px;
@@ -1885,10 +1657,10 @@
       :host(.bar-right) > *:not(style):not(card-mod):not(h1),
       :host(.bar-large-left) > *:not(style):not(card-mod):not(h1),
       :host(.bar-large-right) > *:not(style):not(card-mod):not(h1),
-      ha-card.bar-left > *:not(style):not(card-mod):not(h1),
-      ha-card.bar-large-left:not(div > *) > *:not(style):not(card-mod):not(h1),
-      ha-card.bar-right > *:not(style):not(card-mod):not(h1),
-      ha-card.bar-large-right:not(div > *) > *:not(style):not(card-mod):not(h1) {
+      :host > ha-card.bar-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-large-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-large-right > *:not(style):not(card-mod):not(h1) {
         text-transform: uppercase;
         background-color: var(--lcars-background-color);
         --lcars-primary-text: var(--lcars-background-text);
@@ -1917,10 +1689,10 @@
       :host(.bar-right) > *:not(style):not(card-mod):not(h1) > ha-markdown,
       :host(.bar-large-left) > *:not(style):not(card-mod):not(h1) > ha-markdown,
       :host(.bar-large-right) > *:not(style):not(card-mod):not(h1) > ha-markdown,
-      ha-card.bar-left > *:not(style):not(card-mod):not(h1) > ha-markdown,
-      ha-card.bar-large-left:not(div > *) > *:not(style):not(card-mod):not(h1) > ha-markdown,
-      ha-card.bar-right > *:not(style):not(card-mod):not(h1) > ha-markdown,
-      ha-card.bar-large-right:not(div > *) > *:not(style):not(card-mod):not(h1) > ha-markdown {
+      :host > ha-card.bar-left > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-large-left > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-right > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-large-right > *:not(style):not(card-mod):not(h1) > ha-markdown {
         padding: 0px;
         margin-top: -0.06em;
       }
@@ -1929,10 +1701,10 @@
       :host(.bar-right) .title,
       :host(.bar-large-left) .title,
       :host(.bar-large-right) .title,
-      ha-card.bar-left .title,
-      ha-card.bar-large-left:not(div > *) .title,
-      ha-card.bar-right .title,
-      ha-card.bar-large-right:not(div > *) .title {
+      :host > ha-card.bar-left .title,
+      :host > ha-card.bar-large-left .title,
+      :host > ha-card.bar-right .title,
+      :host > ha-card.bar-large-right .title {
         font-size: inherit !important;
         line-height: 1;
         margin-top: -0.06em;
@@ -1940,22 +1712,22 @@
 
       :host(.bar-large-left),
       :host(.bar-large-right),
-      ha-card.bar-large-left:not(div > *),
-      ha-card.bar-large-right:not(div > *) {
+      :host > ha-card.bar-large-left,
+      :host > ha-card.bar-large-right {
         font-size: 3em;
       }
 
       :host(.bar-left),
       :host(.bar-large-left),
-      ha-card.bar-left,
-      ha-card.bar-large-left:not(div > *) {
+      :host > ha-card.bar-left,
+      :host > ha-card.bar-large-left {
         border-left: var(--lcars-vertical-border) solid var(--lcars-card-top-color);
       }
 
       :host(.bar-right),
       :host(.bar-large-right),
-      ha-card.bar-right,
-      ha-card.bar-large-right:not(div > *) {
+      :host > ha-card.bar-right,
+      :host > ha-card.bar-large-right {
         border-right: var(--lcars-vertical-border) solid var(--lcars-card-top-color);
         text-align: right;
       }
@@ -2059,9 +1831,8 @@
       }
 
       :host(.type-todo-list) > ha-card div.addRow,
-      :host(.type-todo-list)ha-card div.addRow,
       ha-card.type-todo-list > ha-card div.addRow,
-      ha-card.type-todo-listha-card div.addRow {
+      ha-card.type-todo-list div.addRow {
         background-color: var(--lcars-card-bottom-color);
         --mdc-text-field-fill-color: var(--lcars-card-bottom-color);
         color: var(--lcars-card-bottom-text);
@@ -2078,9 +1849,8 @@
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list .header,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list .header,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list .header,
-      ha-card.type-todo-listha-card ha-sortable > ha-list .header {
+      ha-card.type-todo-list ha-sortable > ha-list .header {
         background-color: var(--lcars-card-top-color);
         color: var(--lcars-card-top-text);
         --primary-text-color: var(--lcars-card-top-text);
@@ -2095,16 +1865,14 @@
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list .header h2,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list .header h2,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list .header h2,
-      ha-card.type-todo-listha-card ha-sortable > ha-list .header h2 {
+      ha-card.type-todo-list ha-sortable > ha-list .header h2 {
         padding-bottom: 0.15em;
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list ha-check-list-item,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item,
-      ha-card.type-todo-listha-card ha-sortable > ha-list ha-check-list-item {
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item {
         --check-border-right: 5px;
         --check-border-left: 0px;
         --flex-left: 1;
@@ -2124,24 +1892,21 @@
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item.completed,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list ha-check-list-item.completed,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item.completed,
-      ha-card.type-todo-listha-card ha-sortable > ha-list ha-check-list-item.completed {
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item.completed {
         background-color: var(--completed-color);
         color: var(--completed-text-color);
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon,
-      ha-card.type-todo-listha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon {
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon {
         background-color: var(--completed-text-color);
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox,
-      ha-card.type-todo-listha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox {
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item .mdc-checkbox {
         opacity: 1;
         position: absolute;
       }
@@ -2149,23 +1914,19 @@
       :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
       :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
       :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background,
-      ha-card.type-todo-listha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
-      ha-card.type-todo-listha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
-      ha-card.type-todo-listha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background {
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background {
         border-color: var(--lcars-background-color);
         background-color: var(--lcars-background-color);
       }
 
       :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item .summary,
-      :host(.type-todo-list)ha-card ha-sortable > ha-list ha-check-list-item .summary,
       ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item .summary,
-      ha-card.type-todo-listha-card ha-sortable > ha-list ha-check-list-item .summary {
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item .summary {
         font-size: 1.2rem;
         position: absolute;
         right: max(8px, var(--list-border-right));
@@ -2197,21 +1958,17 @@
       }
 
       :host(.list-lozenge-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      :host(.list-lozenge-right)ha-card > ha-sortable > ha-list > ha-check-list-item,
       :host(.list-bullet-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      :host(.list-bullet-right)ha-card > ha-sortable > ha-list > ha-check-list-item,
       :host(.list-capped-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      :host(.list-capped-right)ha-card > ha-sortable > ha-list > ha-check-list-item,
       :host(.list-barrel-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      :host(.list-barrel-right)ha-card > ha-sortable > ha-list > ha-check-list-item,
       ha-card.list-lozenge-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      ha-card.list-lozenge-rightha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-lozenge-right > ha-sortable > ha-list > ha-check-list-item,
       ha-card.list-bullet-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      ha-card.list-bullet-rightha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-bullet-right > ha-sortable > ha-list > ha-check-list-item,
       ha-card.list-capped-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      ha-card.list-capped-rightha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-capped-right > ha-sortable > ha-list > ha-check-list-item,
       ha-card.list-barrel-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
-      ha-card.list-barrel-rightha-card > ha-sortable > ha-list > ha-check-list-item {
+      ha-card.list-barrel-right > ha-sortable > ha-list > ha-check-list-item {
         flex-direction: row-reverse;
         --check-border-left: 5px;
         --check-border-right: 0px;
@@ -2220,21 +1977,17 @@
       }
 
       :host(.list-lozenge-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      :host(.list-lozenge-right)ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
       :host(.list-bullet-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      :host(.list-bullet-right)ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
       :host(.list-capped-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      :host(.list-capped-right)ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
       :host(.list-barrel-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      :host(.list-barrel-right)ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
       ha-card.list-lozenge-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      ha-card.list-lozenge-rightha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-lozenge-right > ha-sortable > ha-list > ha-check-list-item .summary,
       ha-card.list-bullet-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      ha-card.list-bullet-rightha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-bullet-right > ha-sortable > ha-list > ha-check-list-item .summary,
       ha-card.list-capped-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      ha-card.list-capped-rightha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-capped-right > ha-sortable > ha-list > ha-check-list-item .summary,
       ha-card.list-barrel-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
-      ha-card.list-barrel-rightha-card > ha-sortable > ha-list > ha-check-list-item .summary {
+      ha-card.list-barrel-right > ha-sortable > ha-list > ha-check-list-item .summary {
         right: unset;
         left: max(8px, var(--list-border-left));
       }
@@ -2244,7 +1997,7 @@
         --primary-background-color: var(--lcars-dark-gray);
       }
     # To-Do List Card
-    "ha-card:has(ha-sortable)$": |
+    "ha-card$": |
       h1.card-header {
         background-color: var(--lcars-card-top-color);
         color: var(--lcars-card-top-text);
@@ -2427,7 +2180,7 @@
         --icon-primary-color: var(--lcars-text-light);
       }
 
-      add-view {
+      #add-view {
         background-color: var(--lcars-card-top-color);
         height: 40px;
         border-radius: 0px 0px 0px 0px;
@@ -2476,7 +2229,7 @@
         }
       }
 
-      view {
+      #view {
         --primary-background-color: var(--primary-background-color);
         --lovelace-background: var(--primary-background-color);
         --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
@@ -2496,13 +2249,12 @@
       hui-masonry-view {
         padding-right: 23px;
       }
-      {% if not is_state('input_boolean.lcars_sound', 'on') %}
 
+      {% if not is_state('input_boolean.lcars_sound', 'on') %}
       .header {
         --lcars-sound: false;
       }
       {% else %}
-
       .header {
         --lcars-sound: true;
       }
@@ -2537,7 +2289,7 @@
     "ha-panel-developer-tools $": |
       .header ha-tab-group {
         background-color: var(--lcars-background-color);
-        border-top-left-radius: var(--lcars-inner-radius);
+        border-top-left-radius: var(--lcars-inner-radius) !important;
         --track-width: unset;
       }
 
@@ -2662,11 +2414,11 @@
         }
     "ha-config-dashboard $ ha-top-app-bar-fixed ha-config-section":
       .: |
-        ha-card:has(ha-config-repairs) {
+        ha-card {
           --lcars-alert-color: var(--lcars-alert-red);
         }
 
-        ha-card:has(ha-config-updates) {
+        ha-card {
           --lcars-alert-color: var(--lcars-alert-yellow);
         }
       "ha-card":
@@ -2832,7 +2584,7 @@
           height: calc(2 * var(--lcars-inner-radius) + 2px);
           width: calc(2 * var(--lcars-inner-radius) + 2px);
           background-color: transparent;
-          border-top-left-radius: var(--lcars-inner-radius);
+          border-top-left-radius: var(--lcars-inner-radius) !important;
           box-shadow: calc(var(--lcars-inner-radius) * -1) 0 0 0 var(--lcars-card-top-color);
           margin-top: 0px;
           margin-left: 0px;
@@ -2848,7 +2600,7 @@
           height: calc(2 * var(--lcars-inner-radius) + 2px);
           width: calc(2 * var(--lcars-inner-radius) + 2px);
           background-color: transparent;
-          border-top-right-radius: var(--lcars-inner-radius);
+          border-top-right-radius: var(--lcars-inner-radius) !important;
           box-shadow: calc(var(--lcars-inner-radius)) 0 0 0 var(--lcars-card-top-color);
           margin-top: 0px;
           margin-right: 0px;
@@ -3041,7 +2793,7 @@
   # ===================================================== #
   card-mod-sidebar-yaml: &card-mod-sidebar |
     ha-list-item-button$: |
-      item {
+      #item {
         column-gap: 0;
         padding: 0;
         align-items: stretch;
@@ -3256,6 +3008,16 @@
         box-sizing: border-box;
         width: calc( var(--mdc-icon-size,24px) + 37px);
         padding-block: 8px;
+      }
+
+      ha-list-item-button:not(.configuration):not(.user) > ha-icon,
+      ha-list-item-button:not(.configuration):not(.user) > ha-svg-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        min-width: 61px;
+        height: 100%;
       }
 
       :host([expanded]) {


### PR DESCRIPTION
The python script produced some errors in the flattened CSS after the most recent changes. This update should (does) fix that.