### PR TITLE
fix(themes): Add support for legacy card-primary-color and card-secondary-color

### DIFF
--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -473,6 +473,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
       }
       :host, :host > ha-card {
@@ -522,6 +524,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           border-radius: 0px;
           padding-top: 6px;
@@ -604,6 +608,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           height: 100%;
           box-sizing: border-box;
@@ -686,6 +692,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           padding-bottom: 6px;
           height: 100%;
@@ -780,6 +788,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           text-transform: uppercase;
         }
@@ -798,6 +808,8 @@
           background-color: var(--lcars-card-button-color);
           --lcars-primary-text: var(--lcars-card-button-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           text-transform: uppercase;
         }
       }
@@ -1226,6 +1238,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           border-radius: 0px;
           display: inline-block;
@@ -1361,6 +1375,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
         }
       }
 

--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -807,6 +807,7 @@
         &:is(ha-card) {
           background-color: var(--lcars-card-button-color);
           --lcars-primary-text: var(--lcars-card-button-text);
+          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
           --state-icon-color: var(--lcars-primary-text);
           --card-primary-color: var(--lcars-primary-text);
           --card-secondary-color: var(--lcars-secondary-text);

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -840,6 +840,7 @@
       ha-card.button-bar-right {
         background-color: var(--lcars-card-button-color);
         --lcars-primary-text: var(--lcars-card-button-text);
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
         --state-icon-color: var(--lcars-primary-text);
         --card-primary-color: var(--lcars-primary-text);
         --card-secondary-color: var(--lcars-secondary-text);

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -463,6 +463,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
       }
 
@@ -513,6 +515,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
         border-radius: 0px;
         padding-top: 6px;
@@ -613,6 +617,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
         height: 100%;
         box-sizing: border-box;
@@ -698,6 +704,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
         padding-bottom: 6px;
         height: 100%;
@@ -817,6 +825,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
         text-transform: uppercase;
       }
@@ -831,6 +841,8 @@
         background-color: var(--lcars-card-button-color);
         --lcars-primary-text: var(--lcars-card-button-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         text-transform: uppercase;
       }
 
@@ -1696,6 +1708,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
         border-radius: 0px;
         display: inline-block;
@@ -1825,6 +1839,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
       }
 
       :host.type-custom-html-template-card,

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -473,6 +473,8 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
         --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
       }
       :host, :host > ha-card {
@@ -522,6 +524,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           border-radius: 0px;
           padding-top: 6px;
@@ -604,6 +608,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           height: 100%;
           box-sizing: border-box;
@@ -686,6 +692,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           padding-bottom: 6px;
           height: 100%;
@@ -780,6 +788,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           text-transform: uppercase;
         }
@@ -798,6 +808,8 @@
           background-color: var(--lcars-card-button-color);
           --lcars-primary-text: var(--lcars-card-button-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           text-transform: uppercase;
         }
       }
@@ -1226,6 +1238,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
           color: var(--primary-text-color);
           border-radius: 0px;
           display: inline-block;
@@ -1361,6 +1375,8 @@
           --mdc-text-field-ink-color: var(--lcars-primary-text);
           --wa-form-control-value-color: var(--lcars-primary-text);
           --state-icon-color: var(--lcars-primary-text);
+          --card-primary-color: var(--lcars-primary-text);
+          --card-secondary-color: var(--lcars-secondary-text);
         }
       }
 

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -807,6 +807,7 @@
         &:is(ha-card) {
           background-color: var(--lcars-card-button-color);
           --lcars-primary-text: var(--lcars-card-button-text);
+          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
           --state-icon-color: var(--lcars-primary-text);
           --card-primary-color: var(--lcars-primary-text);
           --card-secondary-color: var(--lcars-secondary-text);


### PR DESCRIPTION
Resolves #229 

Some Mushroom cards still use --lcars-primary-text and --card-secondary-color. The new semantic layer and text color changes in v4.1 lost those. Add them back. 