### PR TITLE
fix(themes): move tonal palette from &base to defaults

### DIFF
--- a/src/defaults.yaml
+++ b/src/defaults.yaml
@@ -87,6 +87,22 @@ success-color: var(--lcars-green)
 warning-color: var(--lcars-sunflower)
 error-color: var(--lcars-dark-red)
 
+# HA tonal palette derived from lcars-ui-tertiary (approximates HA's OKLCH
+# palette generation). Defined here rather than in &base so themes with
+# hand-tuned palettes (the LCARdS variants) override cleanly instead of
+# duplicating keys merged in via <<: *base (issue #232).
+ha-color-primary-05: "color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)"
+ha-color-primary-10: "color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)"
+ha-color-primary-20: "color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)"
+ha-color-primary-30: "color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)"
+ha-color-primary-40: "var(--lcars-ui-tertiary)"
+ha-color-primary-50: "color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)"
+ha-color-primary-60: "color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)"
+ha-color-primary-70: "color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)"
+ha-color-primary-80: "color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)"
+ha-color-primary-90: "color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)"
+ha-color-primary-95: "color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)"
+
 modes:
   light:
     lcars-ui-mix-color: black

--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -271,18 +271,8 @@
 # ======================================================= #
 (DO NOT USE/MODIFY)=== Base customizations: &base
   primary-color: var(--lcars-ui-tertiary)
-  # Tonal palette derived from lcars-ui-tertiary (approximates HA's OKLCH palette generation)
-  ha-color-primary-05: "color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)"
-  ha-color-primary-10: "color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)"
-  ha-color-primary-20: "color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)"
-  ha-color-primary-30: "color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)"
-  ha-color-primary-40: "var(--lcars-ui-tertiary)"
-  ha-color-primary-50: "color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)"
-  ha-color-primary-60: "color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)"
-  ha-color-primary-70: "color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)"
-  ha-color-primary-80: "color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)"
-  ha-color-primary-90: "color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)"
-  ha-color-primary-95: "color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)"
+  # ha-color-primary-* tonal palette lives in src/defaults.yaml so themes can
+  # override it without duplicating keys brought in via <<: *base (issue #232).
   primary-background-color: var(--lcars-background-color)
   secondary-background-color: var(--lcars-ui-quaternary)
   divider-color: transparent

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -271,18 +271,8 @@
 # ======================================================= #
 (DO NOT USE/MODIFY)=== Base customizations: &base
   primary-color: var(--lcars-ui-tertiary)
-  # Tonal palette derived from lcars-ui-tertiary (approximates HA's OKLCH palette generation)
-  ha-color-primary-05: "color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)"
-  ha-color-primary-10: "color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)"
-  ha-color-primary-20: "color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)"
-  ha-color-primary-30: "color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)"
-  ha-color-primary-40: "var(--lcars-ui-tertiary)"
-  ha-color-primary-50: "color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)"
-  ha-color-primary-60: "color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)"
-  ha-color-primary-70: "color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)"
-  ha-color-primary-80: "color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)"
-  ha-color-primary-90: "color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)"
-  ha-color-primary-95: "color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)"
+  # ha-color-primary-* tonal palette lives in src/defaults.yaml so themes can
+  # override it without duplicating keys brought in via <<: *base (issue #232).
   primary-background-color: var(--lcars-background-color)
   secondary-background-color: var(--lcars-ui-quaternary)
   divider-color: transparent
@@ -3322,6 +3312,18 @@ LCARS 25C:
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-light-orange)
   error-color: var(--lcars-alt-orange)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "109,116,140"
   rgb-primary-text-color: "255,255,255"
@@ -3399,6 +3401,18 @@ LCARS 25C (Blue Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "34,102,255"
   rgb-primary-text-color: "255,255,255"
@@ -3478,6 +3492,18 @@ LCARS 25C (Red Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "204,0,0"
   rgb-primary-text-color: "255,255,255"
@@ -3557,6 +3583,18 @@ LCARS 25C (Yellow Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "255,170,0"
   rgb-primary-text-color: "255,255,255"
@@ -3629,6 +3667,18 @@ LCARS Breen:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "15,86,22"
   rgb-primary-text-color: "255,255,255"
@@ -3701,6 +3751,18 @@ LCARS Cardassia:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "79,26,35"
   rgb-primary-text-color: "255,255,255"
@@ -3776,6 +3838,18 @@ LCARS Classic:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -3849,6 +3923,18 @@ LCARS Default:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -3923,6 +4009,18 @@ LCARS Kronos:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "147,10,0"
   rgb-primary-text-color: "255,255,255"
@@ -4307,6 +4405,18 @@ LCARS Lower Decks I:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "145,85,11"
   rgb-primary-text-color: "255,255,255"
@@ -4380,6 +4490,18 @@ LCARS Lower Decks II:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "145,85,11"
   rgb-primary-text-color: "255,255,255"
@@ -4453,6 +4575,18 @@ LCARS Modern:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -4527,6 +4661,18 @@ LCARS Navigation:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-dark-red)
   error-color: var(--lcars-gold)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "130,122,83"
   rgb-primary-text-color: "255,255,255"
@@ -4599,6 +4745,18 @@ LCARS Nemesis Blue:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -4672,6 +4830,18 @@ LCARS Picard I:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "101,107,131"
   rgb-primary-text-color: "255,255,255"
@@ -4748,6 +4918,18 @@ LCARS Picard II:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "1,37,86"
   rgb-primary-text-color: "255,255,255"
@@ -4822,6 +5004,18 @@ LCARS Red Alert:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "54,0,0"
   rgb-primary-text-color: "255,255,255"
@@ -4897,6 +5091,18 @@ LCARS Romulus:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "15,86,22"
   rgb-primary-text-color: "255,255,255"
@@ -4970,6 +5176,18 @@ LCARS TNG:
   success-color: var(--lcars-khaki-light)
   warning-color: var(--lcars-vivid-crimson)
   error-color: var(--lcars-maroon)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -5042,6 +5260,18 @@ LCARS TNGbuttons:
   success-color: var(--lcars-sage)
   warning-color: var(--lcars-vivid-crimson)
   error-color: var(--lcars-maroon)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -5114,6 +5344,18 @@ LCARS Transporter:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-dark-red)
   error-color: var(--lcars-gold)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "44,55,75"
   rgb-primary-text-color: "255,255,255"
@@ -5190,6 +5432,18 @@ LCARS Zeldaar:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "119,68,119"
   rgb-primary-text-color: "255,255,255"

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -271,18 +271,8 @@
 # ======================================================= #
 (DO NOT USE/MODIFY)=== Base customizations: &base
   primary-color: var(--lcars-ui-tertiary)
-  # Tonal palette derived from lcars-ui-tertiary (approximates HA's OKLCH palette generation)
-  ha-color-primary-05: "color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)"
-  ha-color-primary-10: "color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)"
-  ha-color-primary-20: "color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)"
-  ha-color-primary-30: "color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)"
-  ha-color-primary-40: "var(--lcars-ui-tertiary)"
-  ha-color-primary-50: "color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)"
-  ha-color-primary-60: "color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)"
-  ha-color-primary-70: "color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)"
-  ha-color-primary-80: "color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)"
-  ha-color-primary-90: "color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)"
-  ha-color-primary-95: "color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)"
+  # ha-color-primary-* tonal palette lives in src/defaults.yaml so themes can
+  # override it without duplicating keys brought in via <<: *base (issue #232).
   primary-background-color: var(--lcars-background-color)
   secondary-background-color: var(--lcars-ui-quaternary)
   divider-color: transparent
@@ -2815,6 +2805,18 @@ LCARS 25C:
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-light-orange)
   error-color: var(--lcars-alt-orange)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "109,116,140"
   rgb-primary-text-color: "255,255,255"
@@ -2892,6 +2894,18 @@ LCARS 25C (Blue Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "34,102,255"
   rgb-primary-text-color: "255,255,255"
@@ -2971,6 +2985,18 @@ LCARS 25C (Red Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "204,0,0"
   rgb-primary-text-color: "255,255,255"
@@ -3050,6 +3076,18 @@ LCARS 25C (Yellow Alert):
   success-color: var(--lcars-alt-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "255,170,0"
   rgb-primary-text-color: "255,255,255"
@@ -3122,6 +3160,18 @@ LCARS Breen:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "15,86,22"
   rgb-primary-text-color: "255,255,255"
@@ -3194,6 +3244,18 @@ LCARS Cardassia:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "79,26,35"
   rgb-primary-text-color: "255,255,255"
@@ -3269,6 +3331,18 @@ LCARS Classic:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -3342,6 +3416,18 @@ LCARS Default:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -3416,6 +3502,18 @@ LCARS Kronos:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "147,10,0"
   rgb-primary-text-color: "255,255,255"
@@ -3800,6 +3898,18 @@ LCARS Lower Decks I:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "145,85,11"
   rgb-primary-text-color: "255,255,255"
@@ -3873,6 +3983,18 @@ LCARS Lower Decks II:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "145,85,11"
   rgb-primary-text-color: "255,255,255"
@@ -3946,6 +4068,18 @@ LCARS Modern:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "102,102,136"
   rgb-primary-text-color: "255,255,255"
@@ -4020,6 +4154,18 @@ LCARS Navigation:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-dark-red)
   error-color: var(--lcars-gold)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "130,122,83"
   rgb-primary-text-color: "255,255,255"
@@ -4092,6 +4238,18 @@ LCARS Nemesis Blue:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -4165,6 +4323,18 @@ LCARS Picard I:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "101,107,131"
   rgb-primary-text-color: "255,255,255"
@@ -4241,6 +4411,18 @@ LCARS Picard II:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "1,37,86"
   rgb-primary-text-color: "255,255,255"
@@ -4315,6 +4497,18 @@ LCARS Red Alert:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "54,0,0"
   rgb-primary-text-color: "255,255,255"
@@ -4390,6 +4584,18 @@ LCARS Romulus:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "15,86,22"
   rgb-primary-text-color: "255,255,255"
@@ -4463,6 +4669,18 @@ LCARS TNG:
   success-color: var(--lcars-khaki-light)
   warning-color: var(--lcars-vivid-crimson)
   error-color: var(--lcars-maroon)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -4535,6 +4753,18 @@ LCARS TNGbuttons:
   success-color: var(--lcars-sage)
   warning-color: var(--lcars-vivid-crimson)
   error-color: var(--lcars-maroon)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "68,74,119"
   rgb-primary-text-color: "255,255,255"
@@ -4607,6 +4837,18 @@ LCARS Transporter:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-dark-red)
   error-color: var(--lcars-gold)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "44,55,75"
   rgb-primary-text-color: "255,255,255"
@@ -4683,6 +4925,18 @@ LCARS Zeldaar:
   success-color: var(--lcars-green)
   warning-color: var(--lcars-sunflower)
   error-color: var(--lcars-dark-red)
+  # HA Color Palette
+  ha-color-primary-05: color-mix(in oklch, var(--lcars-ui-tertiary) 10%, black)
+  ha-color-primary-10: color-mix(in oklch, var(--lcars-ui-tertiary) 22%, black)
+  ha-color-primary-20: color-mix(in oklch, var(--lcars-ui-tertiary) 44%, black)
+  ha-color-primary-30: color-mix(in oklch, var(--lcars-ui-tertiary) 67%, black)
+  ha-color-primary-40: var(--lcars-ui-tertiary)
+  ha-color-primary-50: color-mix(in oklch, var(--lcars-ui-tertiary) 88%, white)
+  ha-color-primary-60: color-mix(in oklch, var(--lcars-ui-tertiary) 70%, white)
+  ha-color-primary-70: color-mix(in oklch, var(--lcars-ui-tertiary) 50%, white)
+  ha-color-primary-80: color-mix(in oklch, var(--lcars-ui-tertiary) 30%, white)
+  ha-color-primary-90: color-mix(in oklch, var(--lcars-ui-tertiary) 15%, white)
+  ha-color-primary-95: color-mix(in oklch, var(--lcars-ui-tertiary) 8%, white)
   # Derived RGB
   rgb-card-background-color: "119,68,119"
   rgb-primary-text-color: "255,255,255"


### PR DESCRIPTION
## Summary

Fixes #232 — `annotatedyaml` logs 22 "contains duplicate key `ha-color-primary-NN`" warnings per installed theme file on every theme load.

**Root cause:** the `ha-color-primary-05…95` tonal palette added to the `&base` anchor for HA 2026.6 collides with the hand-tuned palettes the two LCARdS Picard themes declare explicitly in their theme blocks. HA's YAML loader flattens `<<: *base` first and then treats each explicit key as a duplicate of the merged-in one (valid YAML 1.1 override, but it warns).

**Fix:** move the palette out of `&base` into `src/defaults.yaml`. The generator merges defaults with per-theme overrides in Python and emits exactly one explicit set per theme block, so no key ever exists in both the anchor and a theme mapping.

- Themes without their own palette get the identical `color-mix(...)` values, now emitted explicitly in each block (24/24 themes carry the palette).
- The LCARdS variants keep their hand-tuned families (verified: `--lcards-blue-darkest`/`--lcards-blue-lightest` endpoints preserved) — these are load-bearing overrides, not redundant: the light end pins to cyan rather than a white tint, and the explicit values don't shift with `modes.dark` tertiary changes the way the derived formula would.

## Test plan

- [x] Generator runs clean; contrast verifier passes (24 themes × 8 slots × 2 modes)
- [x] No `ha-color-primary-*` keys remain in `&base`
- [x] All 24 theme blocks carry exactly one explicit tonal palette
- [x] Scripted check: no explicit theme key collides with any key merged from `&base` / `&lcars-variables`
- [ ] Reporter confirmation: install the built `lcars.yaml`, reload themes, confirm the duplicate-key warnings are gone from the HA log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMn5SX9ZesgNieWqQT7CJi