### PR TITLE
fix(ci): rebase release-impact branch onto origin/master

### DIFF
--- a/.github/workflows/release-impact.yml
+++ b/.github/workflows/release-impact.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Rebase Branch
         uses: martincostello/rebaser@v3.0.1
         with:
-          branch: master
+          # Use the remote-tracking ref: the rebaser passes this straight to
+          # `git rebase`, and a bare `master` has no local branch to resolve
+          # (checkout only creates refs/remotes/origin/master), which failed
+          # with "fatal: invalid upstream 'master'".
+          branch: origin/master
           
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

The scheduled **HA-Frontend Release Impact Analysis** workflow was never actually rebasing its working branch. Its "Rebase Branch" step passed `branch: master` to `martincostello/rebaser`, which forwards the value straight to `git rebase`. But `actions/checkout` only creates the remote-tracking ref `refs/remotes/origin/master` — there's no local `master` branch, and a bare `master` doesn't resolve to a remote-tracking ref. So every run failed with:

```
##[error]Failed to rebase onto master due to an error other than file conflicts:
fatal: invalid upstream 'master'
```

The rebaser writes that outcome to its `result` output **without failing the job**, so all runs stayed green while the `ha-frontend-release-impact-analysis` branch kept accumulating report commits on a base that never advanced (its merge-base with master had been stuck at PR #210).

## Fix

Point the rebaser at `origin/master`, which resolves against the remote-tracking ref checkout already provides with `fetch-depth: 0`. One-word change; no extra step needed. Rebasing onto the remote-tracking ref is also strictly the post-fetch tip, so there's no stale-local-branch risk.

## Notes

- The `ha-frontend-release-impact-analysis` branch was manually rebased onto current master separately, so it's already caught up; this makes the automated rebase work going forward.
- Not included here (deliberately): a guard that fails the job when the rebaser reports `conflicts`/`error`. Worth adding later so a genuine future conflict fails loudly instead of silently stacking again, but out of scope for this fix.

## Test plan

- [x] Workflow YAML parses
- [ ] After merge, next scheduled run's "Rebase Branch" step reports `success`/`upToDate` and the analysis branch's merge-base tracks master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMn5SX9ZesgNieWqQT7CJi