### PR TITLE
fix(themes): per card theme border widths

### DIFF
--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -454,6 +454,24 @@
       /*                Common Card Styles               */
       /* ----------------------------------------------- */
       :host {
+        /* Re-resolve the helper-driven values at card scope. A per-card
+           `theme:` re-applies the theme's compiled defaults as inline styles
+           on the card, shadowing the #view-level helper values (issue #236).
+           Stylesheet !important on the same element wins over those. */
+        --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
+        --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        {% if not is_state('input_boolean.lcars_sound', 'on') %}
+        --lcars-sound: false;
+        {% else %}
+        --lcars-sound: true;
+        {% endif %}
+        {% if not is_state('input_boolean.lcars_texture', 'off') %}
+        --lcars-texture: true;
+        {% else %}
+        --lcars-texture: false;
+        {% endif %}
+
         /* Default card has quaternary background. */
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;

--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -454,23 +454,12 @@
       /*                Common Card Styles               */
       /* ----------------------------------------------- */
       :host {
-        /* Re-resolve the helper-driven values at card scope. A per-card
-           `theme:` re-applies the theme's compiled defaults as inline styles
-           on the card, shadowing the #view-level helper values (issue #236).
-           Stylesheet !important on the same element wins over those. */
+        /* Re-resolve these here for cards with theme overrides */
         --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
-        {% if not is_state('input_boolean.lcars_sound', 'on') %}
-        --lcars-sound: false;
-        {% else %}
-        --lcars-sound: true;
-        {% endif %}
-        {% if not is_state('input_boolean.lcars_texture', 'off') %}
-        --lcars-texture: true;
-        {% else %}
-        --lcars-texture: false;
-        {% endif %}
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
 
         /* Default card has quaternary background. */
         font-family: var(--font-family) !important;
@@ -1952,6 +1941,8 @@
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --menu-font-size: {{ states('input_number.lcars_menu_font') if has_value('input_number.lcars_menu_font') else 24 }}px !important;
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
       }
       hui-view::-webkit-scrollbar {
         display: none;

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -447,6 +447,13 @@
   card-mod-card-yaml: &card-mod-card |
     .: |
       :host {
+        --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
+        --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        --lcars-sound: false;
+        --lcars-sound: true;
+        --lcars-texture: true;
+        --lcars-texture: false;
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;
         --lcars-primary-text: var(--lcars-ui-quaternary-text) !important;

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -450,10 +450,8 @@
         --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
-        --lcars-sound: false;
-        --lcars-sound: true;
-        --lcars-texture: true;
-        --lcars-texture: false;
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;
         --lcars-primary-text: var(--lcars-ui-quaternary-text) !important;
@@ -2468,6 +2466,8 @@
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --menu-font-size: {{ states('input_number.lcars_menu_font') if has_value('input_number.lcars_menu_font') else 24 }}px !important;
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
       }
 
       hui-view::-webkit-scrollbar {

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -454,6 +454,24 @@
       /*                Common Card Styles               */
       /* ----------------------------------------------- */
       :host {
+        /* Re-resolve the helper-driven values at card scope. A per-card
+           `theme:` re-applies the theme's compiled defaults as inline styles
+           on the card, shadowing the #view-level helper values (issue #236).
+           Stylesheet !important on the same element wins over those. */
+        --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
+        --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
+        {% if not is_state('input_boolean.lcars_sound', 'on') %}
+        --lcars-sound: false;
+        {% else %}
+        --lcars-sound: true;
+        {% endif %}
+        {% if not is_state('input_boolean.lcars_texture', 'off') %}
+        --lcars-texture: true;
+        {% else %}
+        --lcars-texture: false;
+        {% endif %}
+
         /* Default card has quaternary background. */
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -454,23 +454,12 @@
       /*                Common Card Styles               */
       /* ----------------------------------------------- */
       :host {
-        /* Re-resolve the helper-driven values at card scope. A per-card
-           `theme:` re-applies the theme's compiled defaults as inline styles
-           on the card, shadowing the #view-level helper values (issue #236).
-           Stylesheet !important on the same element wins over those. */
+        /* Re-resolve these here for cards with theme overrides */
         --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
-        {% if not is_state('input_boolean.lcars_sound', 'on') %}
-        --lcars-sound: false;
-        {% else %}
-        --lcars-sound: true;
-        {% endif %}
-        {% if not is_state('input_boolean.lcars_texture', 'off') %}
-        --lcars-texture: true;
-        {% else %}
-        --lcars-texture: false;
-        {% endif %}
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
 
         /* Default card has quaternary background. */
         font-family: var(--font-family) !important;
@@ -1952,6 +1941,8 @@
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --menu-font-size: {{ states('input_number.lcars_menu_font') if has_value('input_number.lcars_menu_font') else 24 }}px !important;
+        --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
+        --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
       }
       hui-view::-webkit-scrollbar {
         display: none;


### PR DESCRIPTION
Fixes #236.

Repeat the calculation of border sizes (and sound and texture booleans) from helper entities at each hui-card element. This is necessary if the card has a theme override specified. For some reason, between HA and card_mod, the calculated values at the `view` level aren't used by overriden cards, so we have to calculate them here too.

I considered only calculating them at the card level, which is what was done pre-v4. Card_mod can now theme more than the cards and these variables might be useful outside of cards (used to control shapes in the config or profile pages or in the sidebar). 