### PR TITLE
fix(theme): give hover tooltips LCARS-controlled colors

### DIFF
--- a/src/defaults.yaml
+++ b/src/defaults.yaml
@@ -118,6 +118,9 @@ modes:
     lcars-backlight-middle-location: 60%
     lcars-backlight-outer: transparent
     lcars-settings-card-text: var(--lcars-text-light)
+    # hover tooltips (ha-tooltip): sidebar item names, header icons, etc.
+    lcars-tooltip-background: var(--lcars-ui-quaternary)
+    lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   dark:
     lcars-ui-mix-color: white
     lcars-backlight-center: "#ffffff10"
@@ -125,3 +128,6 @@ modes:
     lcars-backlight-middle-location: 70%
     lcars-backlight-outer: "#00000080"
     lcars-settings-card-text: var(--lcars-text-dark)
+    # hover tooltips (ha-tooltip): sidebar item names, header icons, etc.
+    lcars-tooltip-background: var(--lcars-background-color)
+    lcars-tooltip-text: var(--lcars-background-text)

--- a/src/defaults.yaml
+++ b/src/defaults.yaml
@@ -59,6 +59,9 @@ lcars-sidebar-notification-color: var(--lcars-ui-tertiary)
 # UI Text
 # section/view heading titles on dashboards
 lcars-ui-text-heading: var(--lcars-text-gray)
+# Tooltips popups
+lcars-tooltip-background: var(--lcars-ui-quaternary)
+lcars-tooltip-text: var(--lcars-ui-quaternary-text)
 
 # Card colors
 # top bar background of LCARS card sections
@@ -118,9 +121,6 @@ modes:
     lcars-backlight-middle-location: 60%
     lcars-backlight-outer: transparent
     lcars-settings-card-text: var(--lcars-text-light)
-    # hover tooltips (ha-tooltip): sidebar item names, header icons, etc.
-    lcars-tooltip-background: var(--lcars-ui-quaternary)
-    lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   dark:
     lcars-ui-mix-color: white
     lcars-backlight-center: "#ffffff10"
@@ -128,6 +128,3 @@ modes:
     lcars-backlight-middle-location: 70%
     lcars-backlight-outer: "#00000080"
     lcars-settings-card-text: var(--lcars-text-dark)
-    # hover tooltips (ha-tooltip): sidebar item names, header icons, etc.
-    lcars-tooltip-background: var(--lcars-background-color)
-    lcars-tooltip-text: var(--lcars-background-text)

--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -403,6 +403,15 @@
   # Calendar card and panel
   table-header-background-color: var(--ha-color-primary-10)
 
+  # Hover tooltips (ha-tooltip) — sidebar item names, header icons, etc.
+  # Set at theme level (not #view) so tooltips outside the dashboard —
+  # notably the collapsed sidebar's — are covered too. Without these,
+  # ha-tooltip falls back to --ha-color-surface-default (HA near-black in
+  # dark mode) and --primary-text-color, which can collide (issue: black
+  # text on black tooltip in dark mode).
+  ha-tooltip-background-color: var(--lcars-tooltip-background)
+  ha-tooltip-text-color: var(--lcars-tooltip-text)
+
 # ======================================================= #
 #                    CARD MODIFICATIONS                   #
 # ======================================================= #

--- a/src/preamble.yaml
+++ b/src/preamble.yaml
@@ -382,7 +382,7 @@
   markdown-code-text-color: var(--lcars-text-light)
 
   # Fields
-  ha-color-form-background: rgba(0, 0, 0, 0)
+  ha-color-form-background: rgba(0, 0, 0, 0.01)
   ha-color-form-background-hover: rgba(255, 255, 255, 0.05)
   ha-color-form-background-disabled: rgba(0, 0, 0, 0.1)
   ha-color-fill-primary-quiet-resting: rgba(255, 255, 255, 0.1)
@@ -2778,4 +2778,15 @@
       }
       .divider {
         display: none;
+      }
+    "ha-tooltip $": |
+      div.body {
+        padding-top: 9px !important;
+        padding-bottom: 11px !important;
+        min-height: 40px;
+        line-height: var(--menu-font-size);
+        margin-top: -5px;
+        margin-left: -3px;
+        padding-right: 20px;
+        border-radius: 0px 999px 999px 9px;
       }

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -403,6 +403,15 @@
   # Calendar card and panel
   table-header-background-color: var(--ha-color-primary-10)
 
+  # Hover tooltips (ha-tooltip) — sidebar item names, header icons, etc.
+  # Set at theme level (not #view) so tooltips outside the dashboard —
+  # notably the collapsed sidebar's — are covered too. Without these,
+  # ha-tooltip falls back to --ha-color-surface-default (HA near-black in
+  # dark mode) and --primary-text-color, which can collide (issue: black
+  # text on black tooltip in dark mode).
+  ha-tooltip-background-color: var(--lcars-tooltip-background)
+  ha-tooltip-text-color: var(--lcars-tooltip-text)
+
 # ======================================================= #
 #                    CARD MODIFICATIONS                   #
 # ======================================================= #
@@ -3374,6 +3383,8 @@ LCARS 25C:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3381,6 +3392,8 @@ LCARS 25C:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -3465,6 +3478,8 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3472,6 +3487,8 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3560,6 +3577,8 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3567,6 +3586,8 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3655,6 +3676,8 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3662,6 +3685,8 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Breen:
   card-mod-theme: LCARS Breen
@@ -3743,6 +3768,8 @@ LCARS Breen:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3750,6 +3777,8 @@ LCARS Breen:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Cardassia:
   card-mod-theme: LCARS Cardassia
@@ -3831,6 +3860,8 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3838,6 +3869,8 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-mid-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-gray)
@@ -3922,6 +3955,8 @@ LCARS Classic:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3929,6 +3964,8 @@ LCARS Classic:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Default:
@@ -4011,6 +4048,8 @@ LCARS Default:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4018,6 +4057,8 @@ LCARS Default:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-bottom-text: var(--lcars-text-dark)
 
@@ -4101,6 +4142,8 @@ LCARS Kronos:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4108,6 +4151,8 @@ LCARS Kronos:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Picard [LCARdS Blue Accent]:
   card-mod-theme: LCARS Picard [LCARdS Blue Accent]
@@ -4240,6 +4285,8 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -4256,6 +4303,8 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -4400,6 +4449,8 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -4416,6 +4467,8 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -4509,6 +4562,8 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4516,6 +4571,8 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Lower Decks II:
@@ -4598,6 +4655,8 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4605,6 +4664,8 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Modern:
@@ -4687,6 +4748,8 @@ LCARS Modern:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4694,6 +4757,8 @@ LCARS Modern:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-button-text: var(--lcars-text-dark)
 
@@ -4777,6 +4842,8 @@ LCARS Navigation:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4784,6 +4851,8 @@ LCARS Navigation:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Nemesis Blue:
   card-mod-theme: LCARS Nemesis Blue
@@ -4865,6 +4934,8 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4872,6 +4943,8 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
 
 LCARS Picard I:
@@ -4954,6 +5027,8 @@ LCARS Picard I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4961,6 +5036,8 @@ LCARS Picard I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-secondary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -5046,6 +5123,8 @@ LCARS Picard II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5053,6 +5132,8 @@ LCARS Picard II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -5136,6 +5217,8 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5143,6 +5226,8 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-mist)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -5227,6 +5312,8 @@ LCARS Romulus:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5234,6 +5321,8 @@ LCARS Romulus:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-dark)
 
 LCARS TNG:
@@ -5316,6 +5405,8 @@ LCARS TNG:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5323,6 +5414,8 @@ LCARS TNG:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS TNGbuttons:
   card-mod-theme: LCARS TNGbuttons
@@ -5404,6 +5497,8 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5411,6 +5506,8 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Transporter:
   card-mod-theme: LCARS Transporter
@@ -5492,6 +5589,8 @@ LCARS Transporter:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5499,6 +5598,8 @@ LCARS Transporter:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-gray)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-dark)
@@ -5584,6 +5685,8 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5591,6 +5694,8 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 # ================ Paste your themes here =============== |
 # (or add a file to src/themes/ and run generate_themes.py)

--- a/theme_flat/lcars_flat.yaml
+++ b/theme_flat/lcars_flat.yaml
@@ -382,7 +382,7 @@
   markdown-code-text-color: var(--lcars-text-light)
 
   # Fields
-  ha-color-form-background: rgba(0, 0, 0, 0)
+  ha-color-form-background: rgba(0, 0, 0, 0.01)
   ha-color-form-background-hover: rgba(255, 255, 255, 0.05)
   ha-color-form-background-disabled: rgba(0, 0, 0, 0.1)
   ha-color-fill-primary-quiet-resting: rgba(255, 255, 255, 0.1)
@@ -3294,6 +3294,17 @@
       .divider {
         display: none;
       }
+    "ha-tooltip $": |
+      div.body {
+        padding-top: 9px !important;
+        padding-bottom: 11px !important;
+        min-height: 40px;
+        line-height: var(--menu-font-size);
+        margin-top: -5px;
+        margin-left: -3px;
+        padding-right: 20px;
+        border-radius: 0px 999px 999px 9px;
+      }
 # ======================================================= #
 #                    THEME DEFINITIONS                    #
 # ======================================================= #
@@ -3374,6 +3385,8 @@ LCARS 25C:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "109,116,140"
   # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   lcars-tab-selected-bg: url("data:image/svg+xml,%3C!-- sample rectangle --%3E%3Csvg width='256' height='256' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='100%25' height='100%25' fill='transparent'%3E%3Canimate attributeName='fill' values='%23e7442a;%23e7442a;%236d748c' begin='0s' dur='5s' calcMode='discrete' repeatCount='indefinite' /%3E%3C/rect%3E%3C/svg%3E")
   modes:
     light:
@@ -3383,8 +3396,6 @@ LCARS 25C:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3392,8 +3403,6 @@ LCARS 25C:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -3470,6 +3479,9 @@ LCARS 25C (Blue Alert):
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "34,102,255"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3478,8 +3490,6 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3487,8 +3497,6 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3569,6 +3577,9 @@ LCARS 25C (Red Alert):
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "204,0,0"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3577,8 +3588,6 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3586,8 +3595,6 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3668,6 +3675,9 @@ LCARS 25C (Yellow Alert):
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "255,170,0"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3676,8 +3686,6 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3685,8 +3693,6 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Breen:
   card-mod-theme: LCARS Breen
@@ -3760,6 +3766,9 @@ LCARS Breen:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3768,8 +3777,6 @@ LCARS Breen:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3777,8 +3784,6 @@ LCARS Breen:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Cardassia:
   card-mod-theme: LCARS Cardassia
@@ -3852,6 +3857,9 @@ LCARS Cardassia:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "79,26,35"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3860,8 +3868,6 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3869,8 +3875,6 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-mid-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-gray)
@@ -3947,6 +3951,9 @@ LCARS Classic:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -3955,8 +3962,6 @@ LCARS Classic:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3964,8 +3969,6 @@ LCARS Classic:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Default:
@@ -4040,6 +4043,9 @@ LCARS Default:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4048,8 +4054,6 @@ LCARS Default:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4057,8 +4061,6 @@ LCARS Default:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-bottom-text: var(--lcars-text-dark)
 
@@ -4134,6 +4136,9 @@ LCARS Kronos:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "147,10,0"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4142,8 +4147,6 @@ LCARS Kronos:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4151,8 +4154,6 @@ LCARS Kronos:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Picard [LCARdS Blue Accent]:
   card-mod-theme: LCARS Picard [LCARdS Blue Accent]
@@ -4272,6 +4273,8 @@ LCARS Picard [LCARdS Blue Accent]:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "109,116,140"
   # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   lcars-card-mid-left-color: var(--lcards-blue)
   lcars-card-button: var(--lcards-blue)
   lcars-card-button-off: var(--lcards-gray-medium-light)
@@ -4285,8 +4288,6 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -4303,8 +4304,6 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -4436,6 +4435,8 @@ LCARS Picard [LCARdS Red Accent]:
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "109,116,140"
   # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   lcars-card-mid-left-color: var(--lcards-orange)
   lcars-card-button: var(--lcards-orange)
   lcars-card-button-off: var(--lcards-gray-medium-light)
@@ -4449,8 +4450,6 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -4467,8 +4466,6 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -4554,6 +4551,9 @@ LCARS Lower Decks I:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4562,8 +4562,6 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4571,8 +4569,6 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Lower Decks II:
@@ -4647,6 +4643,9 @@ LCARS Lower Decks II:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "145,85,11"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4655,8 +4654,6 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4664,8 +4661,6 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Modern:
@@ -4740,6 +4735,9 @@ LCARS Modern:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "102,102,136"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4748,8 +4746,6 @@ LCARS Modern:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4757,8 +4753,6 @@ LCARS Modern:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-button-text: var(--lcars-text-dark)
 
@@ -4834,6 +4828,9 @@ LCARS Navigation:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "130,122,83"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4842,8 +4839,6 @@ LCARS Navigation:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4851,8 +4846,6 @@ LCARS Navigation:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Nemesis Blue:
   card-mod-theme: LCARS Nemesis Blue
@@ -4926,6 +4919,9 @@ LCARS Nemesis Blue:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -4934,8 +4930,6 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4943,8 +4937,6 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
 
 LCARS Picard I:
@@ -5019,6 +5011,9 @@ LCARS Picard I:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "101,107,131"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5027,8 +5022,6 @@ LCARS Picard I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5036,8 +5029,6 @@ LCARS Picard I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-secondary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -5115,6 +5106,9 @@ LCARS Picard II:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "1,37,86"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5123,8 +5117,6 @@ LCARS Picard II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5132,8 +5124,6 @@ LCARS Picard II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -5209,6 +5199,9 @@ LCARS Red Alert:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "54,0,0"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5217,8 +5210,6 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5226,8 +5217,6 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-mist)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -5304,6 +5293,9 @@ LCARS Romulus:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "15,86,22"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5312,8 +5304,6 @@ LCARS Romulus:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5321,8 +5311,6 @@ LCARS Romulus:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-dark)
 
 LCARS TNG:
@@ -5397,6 +5385,9 @@ LCARS TNG:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5405,8 +5396,6 @@ LCARS TNG:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5414,8 +5403,6 @@ LCARS TNG:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS TNGbuttons:
   card-mod-theme: LCARS TNGbuttons
@@ -5489,6 +5476,9 @@ LCARS TNGbuttons:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "68,74,119"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5497,8 +5487,6 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5506,8 +5494,6 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Transporter:
   card-mod-theme: LCARS Transporter
@@ -5581,6 +5567,9 @@ LCARS Transporter:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "44,55,75"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5589,8 +5578,6 @@ LCARS Transporter:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5598,8 +5585,6 @@ LCARS Transporter:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-gray)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-dark)
@@ -5677,6 +5662,9 @@ LCARS Zeldaar:
   rgb-accent-color: "255,119,0"
   rgb-primary-background-color: "0,0,0"
   rgb-secondary-background-color: "119,68,119"
+  # Theme-specific
+  lcars-tooltip-background: var(--lcars-ui-quaternary)
+  lcars-tooltip-text: var(--lcars-ui-quaternary-text)
   modes:
     light:
       lcars-ui-mix-color: black
@@ -5685,8 +5673,6 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
-      lcars-tooltip-background: var(--lcars-ui-quaternary)
-      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5694,8 +5680,6 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
-      lcars-tooltip-background: var(--lcars-background-color)
-      lcars-tooltip-text: var(--lcars-background-text)
 
 # ================ Paste your themes here =============== |
 # (or add a file to src/themes/ and run generate_themes.py)

--- a/themes/lcars.yaml
+++ b/themes/lcars.yaml
@@ -403,6 +403,15 @@
   # Calendar card and panel
   table-header-background-color: var(--ha-color-primary-10)
 
+  # Hover tooltips (ha-tooltip) — sidebar item names, header icons, etc.
+  # Set at theme level (not #view) so tooltips outside the dashboard —
+  # notably the collapsed sidebar's — are covered too. Without these,
+  # ha-tooltip falls back to --ha-color-surface-default (HA near-black in
+  # dark mode) and --primary-text-color, which can collide (issue: black
+  # text on black tooltip in dark mode).
+  ha-tooltip-background-color: var(--lcars-tooltip-background)
+  ha-tooltip-text-color: var(--lcars-tooltip-text)
+
 # ======================================================= #
 #                    CARD MODIFICATIONS                   #
 # ======================================================= #
@@ -2860,6 +2869,8 @@ LCARS 25C:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -2867,6 +2878,8 @@ LCARS 25C:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -2951,6 +2964,8 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -2958,6 +2973,8 @@ LCARS 25C (Blue Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3046,6 +3063,8 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3053,6 +3072,8 @@ LCARS 25C (Red Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -3141,6 +3162,8 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3148,6 +3171,8 @@ LCARS 25C (Yellow Alert):
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Breen:
   card-mod-theme: LCARS Breen
@@ -3229,6 +3254,8 @@ LCARS Breen:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3236,6 +3263,8 @@ LCARS Breen:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Cardassia:
   card-mod-theme: LCARS Cardassia
@@ -3317,6 +3346,8 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3324,6 +3355,8 @@ LCARS Cardassia:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-mid-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-gray)
@@ -3408,6 +3441,8 @@ LCARS Classic:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3415,6 +3450,8 @@ LCARS Classic:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Default:
@@ -3497,6 +3534,8 @@ LCARS Default:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3504,6 +3543,8 @@ LCARS Default:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-bottom-text: var(--lcars-text-dark)
 
@@ -3587,6 +3628,8 @@ LCARS Kronos:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -3594,6 +3637,8 @@ LCARS Kronos:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Picard [LCARdS Blue Accent]:
   card-mod-theme: LCARS Picard [LCARdS Blue Accent]
@@ -3726,6 +3771,8 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -3742,6 +3789,8 @@ LCARS Picard [LCARdS Blue Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -3886,6 +3935,8 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 40%, transparent)
       lcars-ui-primary: var(--lcards-gray-medium-light)
       lcars-ui-secondary: var(--lcards-gray-light)
@@ -3902,6 +3953,8 @@ LCARS Picard [LCARdS Red Accent]:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       ha-color-form-background: color-mix(in srgb, var(--lcards-moonlight) 30%, transparent)
       lcars-ui-primary: var(--lcards-gray)
       lcars-ui-secondary: var(--lcards-gray-medium-light)
@@ -3995,6 +4048,8 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4002,6 +4057,8 @@ LCARS Lower Decks I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Lower Decks II:
@@ -4084,6 +4141,8 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4091,6 +4150,8 @@ LCARS Lower Decks II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
 
 LCARS Modern:
@@ -4173,6 +4234,8 @@ LCARS Modern:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4180,6 +4243,8 @@ LCARS Modern:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-button-text: var(--lcars-text-dark)
 
@@ -4263,6 +4328,8 @@ LCARS Navigation:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4270,6 +4337,8 @@ LCARS Navigation:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Nemesis Blue:
   card-mod-theme: LCARS Nemesis Blue
@@ -4351,6 +4420,8 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4358,6 +4429,8 @@ LCARS Nemesis Blue:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
 
 LCARS Picard I:
@@ -4440,6 +4513,8 @@ LCARS Picard I:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4447,6 +4522,8 @@ LCARS Picard I:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-secondary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-dark)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -4532,6 +4609,8 @@ LCARS Picard II:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4539,6 +4618,8 @@ LCARS Picard II:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-bottom-text: var(--lcars-text-gray)
 
@@ -4622,6 +4703,8 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4629,6 +4712,8 @@ LCARS Red Alert:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-dark)
       lcars-ui-quaternary-text: var(--lcars-text-mist)
       lcars-card-top-text: var(--lcars-text-dark)
@@ -4713,6 +4798,8 @@ LCARS Romulus:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4720,6 +4807,8 @@ LCARS Romulus:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-card-top-text: var(--lcars-text-dark)
 
 LCARS TNG:
@@ -4802,6 +4891,8 @@ LCARS TNG:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4809,6 +4900,8 @@ LCARS TNG:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS TNGbuttons:
   card-mod-theme: LCARS TNGbuttons
@@ -4890,6 +4983,8 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4897,6 +4992,8 @@ LCARS TNGbuttons:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 LCARS Transporter:
   card-mod-theme: LCARS Transporter
@@ -4978,6 +5075,8 @@ LCARS Transporter:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -4985,6 +5084,8 @@ LCARS Transporter:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
       lcars-ui-primary-text: var(--lcars-text-gray)
       lcars-ui-quaternary-text: var(--lcars-text-gray)
       lcars-card-button-text: var(--lcars-text-dark)
@@ -5070,6 +5171,8 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 60%
       lcars-backlight-outer: transparent
       lcars-settings-card-text: var(--lcars-text-light)
+      lcars-tooltip-background: var(--lcars-ui-quaternary)
+      lcars-tooltip-text: var(--lcars-ui-quaternary-text)
     dark:
       lcars-ui-mix-color: white
       lcars-backlight-center: "#ffffff10"
@@ -5077,6 +5180,8 @@ LCARS Zeldaar:
       lcars-backlight-middle-location: 70%
       lcars-backlight-outer: "#00000080"
       lcars-settings-card-text: var(--lcars-text-dark)
+      lcars-tooltip-background: var(--lcars-background-color)
+      lcars-tooltip-text: var(--lcars-background-text)
 
 # ================ Paste your themes here =============== |
 # (or add a file to src/themes/ and run generate_themes.py)

--- a/themes/lcars_flattened.yaml
+++ b/themes/lcars_flattened.yaml
@@ -417,54 +417,42 @@
 # ======================================================= #
 (DO NOT USE/MODIFY)=== card-mod CSS: &card-mod-css # Card modifications
   card-mod-drawer: |
-    :host {
-      /* ----------------------------------------------- */
-      /*         Dashbaord Texture and Gradient          */
-      /* ----------------------------------------------- */
-      {% if not is_state('input_boolean.lcars_texture', 'off') %}
-      &::before {
-        content: "";
-        background: radial-gradient(ellipse farthest-corner at center center, var(--lcars-backlight-center) 0%, var(--lcars-backlight-middle) var(--lcars-backlight-middle-location), var(--lcars-backlight-outer) 100%);
-        width: 100%;
-        height: 100%;
-        z-index: 9990;
-        position: fixed;
-        mix-blend-mode: overlay;
-        opacity: 1;
-        pointer-events: none;
-      }
-      &::after {
-        content: "";
-        background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        top: 0px;
-        z-index: 9991;
-        mix-blend-mode: overlay;
-        opacity: 1;
-        pointer-events: none;
-      }
-      {% endif %}
+    {% if not is_state('input_boolean.lcars_texture', 'off') %}
+    :host::before {
+      content: "";
+      background: radial-gradient(ellipse farthest-corner at center center, var(--lcars-backlight-center) 0%, var(--lcars-backlight-middle) var(--lcars-backlight-middle-location), var(--lcars-backlight-outer) 100%);
+      width: 100%;
+      height: 100%;
+      z-index: 9990;
+      position: fixed;
+      mix-blend-mode: overlay;
+      opacity: 1;
+      pointer-events: none;
     }
+
+    :host::after {
+      content: "";
+      background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0px;
+      z-index: 9991;
+      mix-blend-mode: overlay;
+      opacity: 1;
+      pointer-events: none;
+    }
+    {% endif %}
   card-mod-card-yaml: &card-mod-card |
     .: |
-      /* ----------------------------------------------- */
-      /*                Common Card Styles               */
-      /* ----------------------------------------------- */
       :host {
-        /* Re-resolve these here for cards with theme overrides */
         --lcars-horizontal-border: {{ states('input_number.lcars_horizontal') if has_value('input_number.lcars_horizontal') else 10 }}px !important;
         --lcars-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-middle-vertical-border: {{ states('input_number.lcars_vertical') if has_value('input_number.lcars_vertical') else 35 }}px !important;
         --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
         --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
-
-        /* Default card has quaternary background. */
         font-family: var(--font-family) !important;
         --md-sys-color-primary: var(--lcars-ui-quaternary) !important;
-
-        /* Force these to be recomputed to prevent eager variable resolution */
         --lcars-primary-text: var(--lcars-ui-quaternary-text) !important;
         --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
         --ha-card-header-color: var(--lcars-primary-text);
@@ -483,27 +471,20 @@
         --card-secondary-color: var(--lcars-secondary-text);
         color: var(--primary-text-color);
       }
-      :host, :host > ha-card {
-        &:not(.type-undefined,.type-custom-grid-layout) {
-          height: 100%;
-        }
 
+      :host:not(.type-undefined):not(.type-custom-grid-layout),
+      :host > ha-card:not(.type-undefined):not(.type-custom-grid-layout) {
+        height: 100%;
       }
-      
-      /* =============================================== */
-      /*        HEADER CLASSES AND CARD TYPE FIXES       */
-      /* =============================================== */
-      
-      /* ------------- Common Header Styles ------------ */
+
       :host(.header-left),
       :host(.header-right),
       :host(.header-contained),
       :host(.header-open),
-      ha-card:is(.header-left,
-                 .header-right,
-                 .header-contained,
-                 .header-open
-      ):not(div > *) {
+      :host > ha-card.header-left,
+      :host > ha-card.header-right,
+      :host > ha-card.header-contained,
+      :host > ha-card.header-open {
         display: block !important;
         height: 100%;
         border: 0px solid var(--lcars-card-top-color);
@@ -513,81 +494,99 @@
         box-sizing: border-box;
         background-color: var(--lcars-card-top-color);
         text-transform: uppercase;
-
-        > :not(style,card-mod,h1) {
-          background-color: var(--lcars-background-color);
-          --lcars-primary-text: var(--lcars-background-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-          color: var(--primary-text-color);
-          border-radius: 0px;
-          padding-top: 6px;
-          height: 100%;
-          box-sizing: border-box;
-        }
-        > ha-markdown,
-        > ha-card > ha-markdown {
-          padding-block: 0px;
-        }
       }
-      
-      /* ----------------Border on left----------------- */
+
+      :host(.header-left) > *:not(style):not(card-mod):not(h1),
+      :host(.header-right) > *:not(style):not(card-mod):not(h1),
+      :host(.header-contained) > *:not(style):not(card-mod):not(h1),
+      :host(.header-open) > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.header-open > *:not(style):not(card-mod):not(h1) {
+        background-color: var(--lcars-background-color);
+        --lcars-primary-text: var(--lcars-background-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
+        color: var(--primary-text-color);
+        border-radius: 0px;
+        padding-top: 6px;
+        height: 100%;
+        box-sizing: border-box;
+      }
+
+      :host(.header-left) > ha-markdown,
+      :host(.header-left) > ha-card > ha-markdown,
+      :host(.header-right) > ha-markdown,
+      :host(.header-right) > ha-card > ha-markdown,
+      :host(.header-contained) > ha-markdown,
+      :host(.header-contained) > ha-card > ha-markdown,
+      :host(.header-open) > ha-markdown,
+      :host(.header-open) > ha-card > ha-markdown,
+      :host > ha-card.header-left > ha-markdown,
+      :host > ha-card.header-left > ha-card > ha-markdown,
+      :host > ha-card.header-right > ha-markdown,
+      :host > ha-card.header-right > ha-card > ha-markdown,
+      :host > ha-card.header-contained > ha-markdown,
+      :host > ha-card.header-contained > ha-card > ha-markdown,
+      :host > ha-card.header-open > ha-markdown,
+      :host > ha-card.header-open > ha-card > ha-markdown {
+        padding-block: 0px;
+      }
+
       :host(.header-left),
       :host(.header-contained),
-      ha-card:is(.header-left,
-                 .header-contained
-      ):not(div > *) {
+      :host > ha-card.header-left,
+      :host > ha-card.header-contained {
         border-top-left-radius: var(--ha-card-border-radius);
         border-left-width: var(--lcars-vertical-border);
-
-        > :not(style,card-mod) {
-          border-top-left-radius: var(--lcars-inner-radius);
-          padding-left: 6px;
-        }
       }
 
-      /* ----------------Border on right---------------- */
+      :host(.header-left) > *:not(style):not(card-mod),
+      :host(.header-contained) > *:not(style):not(card-mod),
+      :host > ha-card.header-left > *:not(style):not(card-mod),
+      :host > ha-card.header-contained > *:not(style):not(card-mod) {
+        border-top-left-radius: var(--lcars-inner-radius) !important;
+        padding-left: 6px;
+      }
+
       :host(.header-right),
       :host(.header-contained),
-      ha-card:is(.header-right,
-                 .header-contained
-      ):not(div > *) {
+      :host > ha-card.header-right,
+      :host > ha-card.header-contained {
         border-top-right-radius: var(--ha-card-border-radius);
         border-right-width: var(--lcars-vertical-border);
-
-        > :not(style,card-mod) {
-          border-top-right-radius: var(--lcars-inner-radius);
-          padding-right: 6px;
-        }
       }
 
-      /* =============================================== */
-      /*        MIDDLE CLASSES AND CARD TYPE FIXES       */
-      /* =============================================== */
+      :host(.header-right) > *:not(style):not(card-mod),
+      :host(.header-contained) > *:not(style):not(card-mod),
+      :host > ha-card.header-right > *:not(style):not(card-mod),
+      :host > ha-card.header-contained > *:not(style):not(card-mod) {
+        border-top-right-radius: var(--lcars-inner-radius) !important;
+        padding-right: 6px;
+      }
 
-      /* ------------- Common Middle Styles ------------ */
       :host(.middle-left),
       :host(.middle-right),
       :host(.middle-contained),
       :host(.middle-blank),
-      ha-card:is(.middle-left,
-                 .middle-right,
-                 .middle-contained,
-                 .middle-blank
-      ):not(div > *)  {
+      :host > ha-card.middle-left,
+      :host > ha-card.middle-right,
+      :host > ha-card.middle-contained,
+      :host > ha-card.middle-blank {
         display: block !important;
         height: 100%;
         background-color: var(--lcars-background-color);
@@ -596,618 +595,1087 @@
         border-radius: 0px;
         border-inline: 0px solid var(--lcars-card-mid-color);
         text-transform: uppercase;
-
-        > :not(style,card-mod,h1) {
-          border-radius: 0px;
-          background-color: var(--lcars-background-color);
-          --lcars-primary-text: var(--lcars-background-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-          color: var(--primary-text-color);
-          height: 100%;
-          box-sizing: border-box;
-        }
       }
+
+      :host(.middle-left) > *:not(style):not(card-mod):not(h1),
+      :host(.middle-right) > *:not(style):not(card-mod):not(h1),
+      :host(.middle-contained) > *:not(style):not(card-mod):not(h1),
+      :host(.middle-blank) > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.middle-blank > *:not(style):not(card-mod):not(h1) {
+        border-radius: 0px;
+        background-color: var(--lcars-background-color);
+        --lcars-primary-text: var(--lcars-background-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
+        color: var(--primary-text-color);
+        height: 100%;
+        box-sizing: border-box;
+      }
+
       > ha-markdown,
       > ha-card > ha-markdown {
         padding-block: 0px;
       }
-      
-      /* -----------------Border on left---------------- */
+
       :host(.middle-left),
       :host(.middle-contained),
-      ha-card:is(.middle-left,
-                 .middle-contained
-      ):not(div > *) {
+      :host > ha-card.middle-left,
+      :host > ha-card.middle-contained {
         border-left-width: var(--lcars-vertical-border);
-        > :not(style,card-mod) {
-          padding-left: 6px;
-        }
       }
 
-      /* ----------------Border on right---------------- */
+      :host(.middle-left) > *:not(style):not(card-mod),
+      :host(.middle-contained) > *:not(style):not(card-mod),
+      :host > ha-card.middle-left > *:not(style):not(card-mod),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod) {
+        padding-left: 6px;
+      }
+
       :host(.middle-right),
       :host(.middle-contained),
-      ha-card:is(.middle-right,
-                 .middle-contained
-      ):not(div > *) {
+      :host > ha-card.middle-right,
+      :host > ha-card.middle-contained {
         border-right-width: var(--lcars-vertical-border);
-        > :not(style,card-mod) {
-          padding-right: 6px;
-        }
       }
 
-      /* -------------- Entities Card padding ---------- */
-      :host(.middle-blank) {
-        #states {
-          padding: 0px;
-        }
+      :host(.middle-right) > *:not(style):not(card-mod),
+      :host(.middle-contained) > *:not(style):not(card-mod),
+      :host > ha-card.middle-right > *:not(style):not(card-mod),
+      :host > ha-card.middle-contained > *:not(style):not(card-mod) {
+        padding-right: 6px;
       }
 
-      /* =============================================== */
-      /*        FOOTER CLASSES AND CARD TYPE FIXES       */
-      /* =============================================== */
-      
-      /* ------------- Common Footer Styles ------------ */
+      :host(.middle-blank) #states {
+        padding: 0px;
+      }
+
       :host(.footer-left),
       :host(.footer-right),
       :host(.footer-contained),
       :host(.footer-open),
-      ha-card:is(.footer-left,
-                 .footer-right,
-                 .footer-contained,
-                 .footer-open
-      ):not(div > *) {
+      :host > ha-card.footer-left,
+      :host > ha-card.footer-right,
+      :host > ha-card.footer-contained,
+      :host > ha-card.footer-open {
         display: block !important;
         height: 100%;
-        padding: 0px;          
+        padding: 0px;
         box-sizing: border-box;
         border-radius: 0px;
         border: 0px solid var(--lcars-card-bottom-color);
         border-bottom-width: var(--lcars-horizontal-border);
         background-color: var(--lcars-card-bottom-color);
         text-transform: uppercase;
-
-        > :not(style,card-mod,h1) {
-          border-radius: 0px;
-          background-color: var(--lcars-background-color);
-          --lcars-primary-text: var(--lcars-background-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-          color: var(--primary-text-color);
-          padding-bottom: 6px;
-          height: 100%;
-          box-sizing: border-box;
-
-        }
-        > ha-markdown,
-        > ha-card > ha-markdown {
-          padding-block: 0px;
-        }
       }
 
-      /* ----------------------------------------------- */
-      /*              Specific Footer Styles             */
-      /* ----------------------------------------------- */
+      :host(.footer-left) > *:not(style):not(card-mod):not(h1),
+      :host(.footer-right) > *:not(style):not(card-mod):not(h1),
+      :host(.footer-contained) > *:not(style):not(card-mod):not(h1),
+      :host(.footer-open) > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.footer-open > *:not(style):not(card-mod):not(h1) {
+        border-radius: 0px;
+        background-color: var(--lcars-background-color);
+        --lcars-primary-text: var(--lcars-background-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
+        color: var(--primary-text-color);
+        padding-bottom: 6px;
+        height: 100%;
+        box-sizing: border-box;
+      }
 
-      /* -----------------Border on left---------------- */
+      :host(.footer-left) > ha-markdown,
+      :host(.footer-left) > ha-card > ha-markdown,
+      :host(.footer-right) > ha-markdown,
+      :host(.footer-right) > ha-card > ha-markdown,
+      :host(.footer-contained) > ha-markdown,
+      :host(.footer-contained) > ha-card > ha-markdown,
+      :host(.footer-open) > ha-markdown,
+      :host(.footer-open) > ha-card > ha-markdown,
+      :host > ha-card.footer-left > ha-markdown,
+      :host > ha-card.footer-left > ha-card > ha-markdown,
+      :host > ha-card.footer-right > ha-markdown,
+      :host > ha-card.footer-right > ha-card > ha-markdown,
+      :host > ha-card.footer-contained > ha-markdown,
+      :host > ha-card.footer-contained > ha-card > ha-markdown,
+      :host > ha-card.footer-open > ha-markdown,
+      :host > ha-card.footer-open > ha-card > ha-markdown {
+        padding-block: 0px;
+      }
+
       :host(.footer-left),
       :host(.footer-contained),
-      ha-card:is(.footer-left,
-                 .footer-contained
-      ):not(div > *)  {
+      :host > ha-card.footer-left,
+      :host > ha-card.footer-contained {
         border-bottom-left-radius: var(--ha-card-border-radius) !important;
         border-left-width: var(--lcars-vertical-border);
-
-        > :not(style,card-mod) {
-          border-bottom-left-radius: var(--lcars-inner-radius) !important;
-          padding-left: 6px;
-        }
       }
 
-      /* ----------------Border on right---------------- */
+      :host(.footer-left) > *:not(style):not(card-mod),
+      :host(.footer-contained) > *:not(style):not(card-mod),
+      :host > ha-card.footer-left > *:not(style):not(card-mod),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod) {
+        border-bottom-left-radius: var(--lcars-inner-radius) !important;
+        padding-left: 6px;
+      }
+
       :host(.footer-right),
       :host(.footer-contained),
-      ha-card:is(.footer-right,
-                 .footer-contained
-      ):not(div > *)  {
+      :host > ha-card.footer-right,
+      :host > ha-card.footer-contained {
         border-bottom-right-radius: var(--ha-card-border-radius) !important;
         border-right-width: var(--lcars-vertical-border);
-
-        > :not(style,card-mod) {
-          border-bottom-right-radius: var(--lcars-inner-radius) !important;
-          padding-right: 6px;
-        }
       }
 
-      /* =============================================== */
-      /*                     BUTTONS                     */
-      /* =============================================== */
-
-      /* ----------------------------------------------- */
-      /*               Common Button Styles              */
-      /* ----------------------------------------------- */
-      :host(.button-small),
-      :host(.button-large),
-      :host(.button-lozenge-left),
-      :host(.button-lozenge-right),
-      :host(.button-bullet-left),
-      :host(.button-bullet-right),
-      :host(.button-capped-left),
-      :host(.button-capped-right),
-      :host(.button-barrel-left),
-      :host(.button-barrel-right),
-      :host(.button-bar-left),
-      :host(.button-bar-right),
-      ha-card:is(
-        .button-small,
-        .button-large,
-        .button-lozenge-left,
-        .button-lozenge-right,
-        .button-bullet-left,
-        .button-bullet-right,
-        .button-capped-left,
-        .button-capped-right,
-        .button-barrel-left,
-        .button-barrel-right,
-        .button-bar-left,
-        .button-bar-right
-      ) {
-
-        > ha-card,
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-          background-color: var(--lcars-card-button-color);
-          --lcars-primary-text: var(--lcars-card-button-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-          color: var(--primary-text-color);
-          text-transform: uppercase;
-
-          /* Louder ripple press feedback to handle wide range in colors */
-          --ha-ripple-color: var(--lcars-ripple-color);
-          --ha-ripple-pressed-opacity: var(--lcars-ripple-pressed-opacity);
-          --ha-ripple-hover-opacity: var(--lcars-ripple-hover-opacity);
-        }
+      :host(.footer-right) > *:not(style):not(card-mod),
+      :host(.footer-contained) > *:not(style):not(card-mod),
+      :host > ha-card.footer-right > *:not(style):not(card-mod),
+      :host > ha-card.footer-contained > *:not(style):not(card-mod) {
+        border-bottom-right-radius: var(--lcars-inner-radius) !important;
+        padding-right: 6px;
       }
 
-      /* ----------------------------------------------- */
-      /*           Small Button Class and Fixes          */
-      /* ----------------------------------------------- */
-      :host(.button-small),
-      ha-card:is(.button-small) {
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-          display: flex;
-          border-radius: 0px !important;
-          position: relative;
-          flex-direction: column;
-          flex-wrap: nowrap;
-          justify-content: center;
-          
-          > .more-info {
-            display: none;
-          }
-          > .content {
-            > #controls {
-              display: flex;
-              place-content: flex-start center;
-              position: relative; 
-              padding: 0px;
-            }
-            > #info {
-              text-align: right;
-              box-sizing: border-box;
-              width: 100%;
-              padding: 0px 6px 6px 0px;
-              margin-top: -24px;
-              position: relative;
-            }
-          }
-
-          > span {
-            box-sizing: border-box;
-            text-align: right;
-            width: 100%;
-            padding: 6px;
-            margin: unset;
-            position: absolute;
-            bottom: 0;
-          }
-
-          > span.state {
-            text-align: right;
-            width: 100%;
-            padding: 6px;
-            padding-bottom: 22px;
-            margin: unset;
-            position: absolute;
-            bottom: 0;
-          }
-        }
+      :host(.button-small) > ha-card,
+      :host(.button-small) > #aspect-ratio > ha-card,
+      :host(.button-large) > ha-card,
+      :host(.button-large) > #aspect-ratio > ha-card,
+      :host(.button-lozenge-left) > ha-card,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card,
+      :host(.button-lozenge-right) > ha-card,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card,
+      :host(.button-bullet-left) > ha-card,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card,
+      :host(.button-bullet-right) > ha-card,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card,
+      :host(.button-capped-left) > ha-card,
+      :host(.button-capped-left) > #aspect-ratio > ha-card,
+      :host(.button-capped-right) > ha-card,
+      :host(.button-capped-right) > #aspect-ratio > ha-card,
+      :host(.button-barrel-left) > ha-card,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card,
+      :host(.button-barrel-right) > ha-card,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card,
+      :host(.button-bar-left) > ha-card,
+      :host(.button-bar-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-large > ha-card,
+      ha-card.button-large > #aspect-ratio > ha-card,
+      ha-card.button-large,
+      ha-card.button-lozenge-left > ha-card,
+      ha-card.button-lozenge-left > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-left,
+      ha-card.button-lozenge-right > ha-card,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-right,
+      ha-card.button-bullet-left > ha-card,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card,
+      ha-card.button-bullet-left,
+      ha-card.button-bullet-right > ha-card,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card,
+      ha-card.button-bullet-right,
+      ha-card.button-capped-left > ha-card,
+      ha-card.button-capped-left > #aspect-ratio > ha-card,
+      ha-card.button-capped-left,
+      ha-card.button-capped-right > ha-card,
+      ha-card.button-capped-right > #aspect-ratio > ha-card,
+      ha-card.button-capped-right,
+      ha-card.button-barrel-left > ha-card,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card,
+      ha-card.button-barrel-left,
+      ha-card.button-barrel-right > ha-card,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card,
+      ha-card.button-barrel-right,
+      ha-card.button-bar-left > ha-card,
+      ha-card.button-bar-left > #aspect-ratio > ha-card,
+      ha-card.button-bar-left,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        background-color: var(--lcars-card-button-color);
+        --lcars-primary-text: var(--lcars-card-button-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
+        color: var(--primary-text-color);
+        text-transform: uppercase;
+        --ha-ripple-color: var(--lcars-ripple-color);
+        --ha-ripple-pressed-opacity: var(--lcars-ripple-pressed-opacity);
+        --ha-ripple-hover-opacity: var(--lcars-ripple-hover-opacity);
       }
 
-      /* ----------------------------------------------- */
-      /*           Large Button Class and Fixes          */
-      /* ----------------------------------------------- */
-      /* None... amazingly */
-      
-      /* =============================================== */
-      /*      BULLET/LOZENGE/CAPPED/BARREL BUTTONS       */
-      /* =============================================== */
-      /* These must handle all possible applications of  */
-      /* the classes by card-mod. That includes both     */
-      /* :host and ha-card because nesting a card in     */
-      /* stacks, layout-card, etc will affect where the  */
-      /* class is applied.                               */
-
-      :host(.button-lozenge-left),
-      :host(.button-lozenge-right),
-      :host(.button-bullet-left),
-      :host(.button-bullet-right),
-      :host(.button-capped-left),
-      :host(.button-capped-right),
-      :host(.button-barrel-left),
-      :host(.button-barrel-right),
-      :host(.button-bar-left),
-      :host(.button-bar-right),
-      ha-card:is(
-        .button-lozenge-left,
-        .button-lozenge-right,
-        .button-bullet-left,
-        .button-bullet-right,
-        .button-capped-left,
-        .button-capped-right,
-        .button-barrel-left,
-        .button-barrel-right,
-        .button-bar-left,
-        .button-bar-right
-      ) {
-
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-        
-          min-height: 60px;
-          display: flex;
-          align-items: flex-end;
-          flex-direction: column-reverse;
-          border-radius: 0px;
-          padding-block: 0px;
-
-          > ha-state-icon {
-            --mdc-icon-size: unset;
-            background-color: var(--lcars-card-top-color);
-            position: absolute;
-            left: 0;
-            width: var(--lcars-vertical-border);
-            height: 100% !important;
-            max-height: 100% !important;
-            border-right: var(--lcars-background-color) solid 6px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-          }
-          
-          > span {
-            width: 100%;
-            height: 100%;
-            display: flex;
-            align-items: flex-end;
-            justify-content: flex-end;
-            margin-top: unset;
-            padding: 6px;
-          }
-          
-          > span.state {
-            align-items: center;
-            color: var(--lcars-card-button-text);
-          }
-
-          /* Big Slider Card */
-          &:is(#container) {
-            > #slider {
-              right: 0;
-              left: calc(var(--lcars-vertical-border) + 6px);
-              background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
-            }
-            > #content {
-              padding-left: calc(var(--lcars-vertical-border) + 18px);
-              justify-content: right;
-            }
-          }
-        }
-      }
-      
-      /* ----------------------------------------------- */
-      /*               Flip Right Buttons                */
-      /* ----------------------------------------------- */
-      :host(.button-lozenge-right),
-      :host(.button-bullet-right),
-      :host(.button-capped-right),
-      :host(.button-barrel-right),
-      ha-card:is(
-        .button-lozenge-right,
-        .button-bullet-right,
-        .button-capped-right,
-        .button-barrel-right
-      ) {
-
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-
-          align-items: flex-start;
-
-          > ha-state-icon {
-            left: auto;
-            right: 0;
-            border-right: 0px;
-            border-left: var(--lcars-background-color) solid 6px;
-          }
-          
-          > span {
-            justify-content: flex-start;
-            left: var(--lcars-vertical-border);
-            padding-inline: 6px;
-          }
-          
-          /* Big Slider Card */
-          &:is(#container) {
-            > #slider {
-              right: calc(var(--lcars-vertical-border) + 6px);
-              left: 0;
-              background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
-            }
-            > #content {
-              padding-left: var(--ha-card-border-radius);
-              padding-right: 0px;
-              justify-content: left;
-            }
-          }
-        }
+      :host(.button-small) > ha-card,
+      :host(.button-small) > #aspect-ratio > ha-card,
+      ha-card.button-small > ha-card,
+      ha-card.button-small > #aspect-ratio > ha-card,
+      ha-card.button-small {
+        display: flex;
+        border-radius: 0px !important;
+        position: relative;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        justify-content: center;
       }
 
-
-      /* ----------------------------------------------- */
-      /*                   Corner Radii                  */
-      /* ----------------------------------------------- */
-      :host(.button-lozenge-left),
-      :host(.button-lozenge-right),
-      :host(.button-bullet-left),
-      :host(.button-capped-right),
-      :host(.button-bar-left),
-      :host(.button-bar-right),
-      ha-card:is(
-        .button-lozenge-left,
-        .button-bullet-left,
-        .button-bar-left,
-        .button-lozenge-right,
-        .button-capped-right,
-        .button-bar-right
-      ) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-          border-top-right-radius: var(--ha-card-border-radius);
-          border-bottom-right-radius: var(--ha-card-border-radius);
-        }
-      }
-      :host(.button-lozenge-left),
-      :host(.button-lozenge-right),
-      :host(.button-bullet-right),
-      :host(.button-capped-left),
-      :host(.button-bar-left),
-      :host(.button-bar-right),
-      ha-card:is(
-        .button-lozenge-left,
-        .button-capped-left,
-        .button-bar-left,
-        .button-lozenge-right,
-        .button-bullet-right,
-        .button-bar-right
-      ) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-      
-          border-top-left-radius: var(--ha-card-border-radius);
-          border-bottom-left-radius: var(--ha-card-border-radius);
-        }
-      }
-      :host(.button-lozenge-left), 
-      :host(.button-bullet-left),
-      ha-card:is(
-        .button-lozenge-left,
-        .button-bullet-left
-      ) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-          > span {
-            padding-right: var(--ha-card-border-radius);
-          }
-        }
-      }
-      :host(.button-lozenge-right), 
-      :host(.button-bullet-right),
-      ha-card:is(
-        .button-lozenge-right,
-        .button-bullet-right
-      ) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-          > span {
-            padding-left: var(--ha-card-border-radius);
-          }
-        }
+      :host(.button-small) > ha-card > .more-info,
+      :host(.button-small) > #aspect-ratio > ha-card > .more-info,
+      ha-card.button-small > ha-card > .more-info,
+      ha-card.button-small > #aspect-ratio > ha-card > .more-info,
+      ha-card.button-small > .more-info {
+        display: none;
       }
 
-      /* ----------------------------------------------- */
-      /*                  Button Bar                     */
-      /* ----------------------------------------------- */
-      :host(.button-bar-left),
-      :host(.button-bar-right),
-      ha-card:is(
-        .button-bar-left,
-        .button-bar-right
-      ) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-
-          line-height: 60px;
-          font-size: 60px;
-          padding-left: var(--lcars-vertical-border);
-          flex-direction: row;
-          justify-content: space-between;
-
-          > span {
-            width: fit-content;
-            padding: 0px;
-
-            &:is(.state) {
-              padding-right: var(--ha-card-border-radius);
-              height: 100%;
-            }
-
-            &:not(.state) { 
-              color: var(--lcars-background-text);
-              height: 100%;
-              background-color: var(--lcars-background-color);
-              padding-inline: 6px;
-              padding-bottom: 0.05em;
-              margin-top: -0.5em;
-            }
-          }
-          
-          > ha-state-icon {
-            font-size: 0;
-          }
-          
-          /* Big Slider Card */
-          &:is(#container) {
-            > #slider {
-              right: 0;
-              left: calc(var(--lcars-vertical-border) + 6px);
-              background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
-            }
-            > #content {
-              position: relative;
-              padding-right: var(--ha-card-border-radius);
-              padding-left: 18px;
-              padding-bottom: 0.1em;
-              justify-content: left;
-            }
-          }
-          
-        }
+      :host(.button-small) > ha-card > .content > #controls,
+      :host(.button-small) > #aspect-ratio > ha-card > .content > #controls,
+      ha-card.button-small > ha-card > .content > #controls,
+      ha-card.button-small > #aspect-ratio > ha-card > .content > #controls,
+      ha-card.button-small > .content > #controls {
+        display: flex;
+        place-content: flex-start center;
+        position: relative;
+        padding: 0px;
       }
 
-      :host(.button-bar-right),
-      ha-card:is(.button-bar-right) {
-        > ha-card#container,
-        > ha-card, 
-        > #aspect-ratio > ha-card,
-        &:is(ha-card) {
-
-          flex-direction: row-reverse;
-          padding-left: 0;
-          padding-right: var(--lcars-vertical-border);
-
-          > span:is(.state) {
-              padding-left: var(--ha-card-border-radius);
-              padding-right: 0;
-          }
-
-          > ha-state-icon {
-            left: auto;
-            right: 0;
-            border-right: 0px;
-            border-left: var(--lcars-background-color) solid 6px;
-          }
-
-          /* Big Slider Card */
-          &:is(#container) {
-            > #slider {
-              right: calc(var(--lcars-vertical-border) + 6px);
-              left: 0;
-              background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
-            }
-            > #content {
-              padding-left: var(--ha-card-border-radius);
-              padding-right: 18px;
-              justify-content: right;
-            }
-          }
-        }
-        
+      :host(.button-small) > ha-card > .content > #info,
+      :host(.button-small) > #aspect-ratio > ha-card > .content > #info,
+      ha-card.button-small > ha-card > .content > #info,
+      ha-card.button-small > #aspect-ratio > ha-card > .content > #info,
+      ha-card.button-small > .content > #info {
+        text-align: right;
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0px 6px 6px 0px;
+        margin-top: -24px;
+        position: relative;
       }
 
+      :host(.button-small) > ha-card > span,
+      :host(.button-small) > #aspect-ratio > ha-card > span,
+      ha-card.button-small > ha-card > span,
+      ha-card.button-small > #aspect-ratio > ha-card > span,
+      ha-card.button-small > span {
+        box-sizing: border-box;
+        text-align: right;
+        width: 100%;
+        padding: 6px;
+        margin: unset;
+        position: absolute;
+        bottom: 0;
+      }
 
-      /* =============================================== */
-      /*                    BAR STYLES                   */
-      /* =============================================== */
+      :host(.button-small) > ha-card > span.state,
+      :host(.button-small) > #aspect-ratio > ha-card > span.state,
+      ha-card.button-small > ha-card > span.state,
+      ha-card.button-small > #aspect-ratio > ha-card > span.state,
+      ha-card.button-small > span.state {
+        text-align: right;
+        width: 100%;
+        padding: 6px;
+        padding-bottom: 22px;
+        margin: unset;
+        position: absolute;
+        bottom: 0;
+      }
 
-      /* ----------------------------------------------- */
-      /*                Common Bar Styles                */
-      /* ----------------------------------------------- */
+      :host(.button-lozenge-left) > ha-card,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card,
+      :host(.button-lozenge-right) > ha-card,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card,
+      :host(.button-bullet-left) > ha-card,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card,
+      :host(.button-bullet-right) > ha-card,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card,
+      :host(.button-capped-left) > ha-card,
+      :host(.button-capped-left) > #aspect-ratio > ha-card,
+      :host(.button-capped-right) > ha-card,
+      :host(.button-capped-right) > #aspect-ratio > ha-card,
+      :host(.button-barrel-left) > ha-card,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card,
+      :host(.button-barrel-right) > ha-card,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card,
+      :host(.button-bar-left) > ha-card,
+      :host(.button-bar-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-right > ha-card,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-right,
+      ha-card.button-bullet-left > ha-card,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card,
+      ha-card.button-bullet-left,
+      ha-card.button-bullet-right > ha-card,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card,
+      ha-card.button-bullet-right,
+      ha-card.button-capped-left > ha-card,
+      ha-card.button-capped-left > #aspect-ratio > ha-card,
+      ha-card.button-capped-left,
+      ha-card.button-capped-right > ha-card,
+      ha-card.button-capped-right > #aspect-ratio > ha-card,
+      ha-card.button-capped-right,
+      ha-card.button-barrel-left > ha-card,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card,
+      ha-card.button-barrel-left,
+      ha-card.button-barrel-right > ha-card,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card,
+      ha-card.button-barrel-right,
+      ha-card.button-bar-left > ha-card,
+      ha-card.button-bar-left > #aspect-ratio > ha-card,
+      ha-card.button-bar-left,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        min-height: 60px;
+        display: flex;
+        align-items: flex-end;
+        flex-direction: column-reverse;
+        border-radius: 0px;
+        padding-block: 0px;
+      }
+
+      :host(.button-lozenge-left) > ha-card > ha-state-icon,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-lozenge-right) > ha-card > ha-state-icon,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bullet-left) > ha-card > ha-state-icon,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bullet-right) > ha-card > ha-state-icon,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-capped-left) > ha-card > ha-state-icon,
+      :host(.button-capped-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-capped-right) > ha-card > ha-state-icon,
+      :host(.button-capped-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-barrel-left) > ha-card > ha-state-icon,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-barrel-right) > ha-card > ha-state-icon,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bar-left) > ha-card > ha-state-icon,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bar-right) > ha-card > ha-state-icon,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-lozenge-right > ha-card > ha-state-icon,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-lozenge-right > ha-state-icon,
+      ha-card.button-bullet-left > ha-card > ha-state-icon,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bullet-left > ha-state-icon,
+      ha-card.button-bullet-right > ha-card > ha-state-icon,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bullet-right > ha-state-icon,
+      ha-card.button-capped-left > ha-card > ha-state-icon,
+      ha-card.button-capped-left > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-capped-left > ha-state-icon,
+      ha-card.button-capped-right > ha-card > ha-state-icon,
+      ha-card.button-capped-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-capped-right > ha-state-icon,
+      ha-card.button-barrel-left > ha-card > ha-state-icon,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-barrel-left > ha-state-icon,
+      ha-card.button-barrel-right > ha-card > ha-state-icon,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-barrel-right > ha-state-icon,
+      ha-card.button-bar-left > ha-card > ha-state-icon,
+      ha-card.button-bar-left > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-left > ha-state-icon,
+      ha-card.button-bar-right > ha-card > ha-state-icon,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-right > ha-state-icon {
+        --mdc-icon-size: unset;
+        background-color: var(--lcars-card-top-color);
+        position: absolute;
+        left: 0;
+        width: var(--lcars-vertical-border);
+        height: 100% !important;
+        max-height: 100% !important;
+        border-right: var(--lcars-background-color) solid 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      :host(.button-lozenge-left) > ha-card > span,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card > span,
+      :host(.button-lozenge-right) > ha-card > span,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
+      :host(.button-bullet-left) > ha-card > span,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card > span,
+      :host(.button-bullet-right) > ha-card > span,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
+      :host(.button-capped-left) > ha-card > span,
+      :host(.button-capped-left) > #aspect-ratio > ha-card > span,
+      :host(.button-capped-right) > ha-card > span,
+      :host(.button-capped-right) > #aspect-ratio > ha-card > span,
+      :host(.button-barrel-left) > ha-card > span,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card > span,
+      :host(.button-barrel-right) > ha-card > span,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card > span,
+      :host(.button-bar-left) > ha-card > span,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > span,
+      :host(.button-bar-right) > ha-card > span,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span,
+      ha-card.button-lozenge-right > ha-card > span,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card > span,
+      ha-card.button-lozenge-right > span,
+      ha-card.button-bullet-left > ha-card > span,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-left > span,
+      ha-card.button-bullet-right > ha-card > span,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-right > span,
+      ha-card.button-capped-left > ha-card > span,
+      ha-card.button-capped-left > #aspect-ratio > ha-card > span,
+      ha-card.button-capped-left > span,
+      ha-card.button-capped-right > ha-card > span,
+      ha-card.button-capped-right > #aspect-ratio > ha-card > span,
+      ha-card.button-capped-right > span,
+      ha-card.button-barrel-left > ha-card > span,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card > span,
+      ha-card.button-barrel-left > span,
+      ha-card.button-barrel-right > ha-card > span,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card > span,
+      ha-card.button-barrel-right > span,
+      ha-card.button-bar-left > ha-card > span,
+      ha-card.button-bar-left > #aspect-ratio > ha-card > span,
+      ha-card.button-bar-left > span,
+      ha-card.button-bar-right > ha-card > span,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span,
+      ha-card.button-bar-right > span {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-end;
+        justify-content: flex-end;
+        margin-top: unset;
+        padding: 6px;
+      }
+
+      :host(.button-lozenge-left) > ha-card > span.state,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-lozenge-right) > ha-card > span.state,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > span.state,
+      :host(.button-bullet-left) > ha-card > span.state,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-bullet-right) > ha-card > span.state,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > span.state,
+      :host(.button-capped-left) > ha-card > span.state,
+      :host(.button-capped-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-capped-right) > ha-card > span.state,
+      :host(.button-capped-right) > #aspect-ratio > ha-card > span.state,
+      :host(.button-barrel-left) > ha-card > span.state,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-barrel-right) > ha-card > span.state,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card > span.state,
+      :host(.button-bar-left) > ha-card > span.state,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-bar-right) > ha-card > span.state,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
+      ha-card.button-lozenge-right > ha-card > span.state,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-lozenge-right > span.state,
+      ha-card.button-bullet-left > ha-card > span.state,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bullet-left > span.state,
+      ha-card.button-bullet-right > ha-card > span.state,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bullet-right > span.state,
+      ha-card.button-capped-left > ha-card > span.state,
+      ha-card.button-capped-left > #aspect-ratio > ha-card > span.state,
+      ha-card.button-capped-left > span.state,
+      ha-card.button-capped-right > ha-card > span.state,
+      ha-card.button-capped-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-capped-right > span.state,
+      ha-card.button-barrel-left > ha-card > span.state,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card > span.state,
+      ha-card.button-barrel-left > span.state,
+      ha-card.button-barrel-right > ha-card > span.state,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-barrel-right > span.state,
+      ha-card.button-bar-left > ha-card > span.state,
+      ha-card.button-bar-left > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-left > span.state,
+      ha-card.button-bar-right > ha-card > span.state,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-right > span.state {
+        align-items: center;
+        color: var(--lcars-card-button-text);
+      }
+
+      :host(.button-lozenge-left) > ha-card#container > #slider,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-lozenge-right) > ha-card#container > #slider,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bullet-left) > ha-card#container > #slider,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bullet-right) > ha-card#container > #slider,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-capped-left) > ha-card#container > #slider,
+      :host(.button-capped-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-capped-right) > ha-card#container > #slider,
+      :host(.button-capped-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-barrel-left) > ha-card#container > #slider,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-barrel-right) > ha-card#container > #slider,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bar-left) > ha-card#container > #slider,
+      :host(.button-bar-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bar-right) > ha-card#container > #slider,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-lozenge-right > ha-card#container > #slider,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-lozenge-right#container > #slider,
+      ha-card.button-bullet-left > ha-card#container > #slider,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bullet-left#container > #slider,
+      ha-card.button-bullet-right > ha-card#container > #slider,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bullet-right#container > #slider,
+      ha-card.button-capped-left > ha-card#container > #slider,
+      ha-card.button-capped-left > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-capped-left#container > #slider,
+      ha-card.button-capped-right > ha-card#container > #slider,
+      ha-card.button-capped-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-capped-right#container > #slider,
+      ha-card.button-barrel-left > ha-card#container > #slider,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-barrel-left#container > #slider,
+      ha-card.button-barrel-right > ha-card#container > #slider,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-barrel-right#container > #slider,
+      ha-card.button-bar-left > ha-card#container > #slider,
+      ha-card.button-bar-left > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-left#container > #slider,
+      ha-card.button-bar-right > ha-card#container > #slider,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-right#container > #slider {
+        right: 0;
+        left: calc(var(--lcars-vertical-border) + 6px);
+        background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
+      }
+
+      :host(.button-lozenge-left) > ha-card#container > #content,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-lozenge-right) > ha-card#container > #content,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bullet-left) > ha-card#container > #content,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bullet-right) > ha-card#container > #content,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-capped-left) > ha-card#container > #content,
+      :host(.button-capped-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-capped-right) > ha-card#container > #content,
+      :host(.button-capped-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-barrel-left) > ha-card#container > #content,
+      :host(.button-barrel-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-barrel-right) > ha-card#container > #content,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bar-left) > ha-card#container > #content,
+      :host(.button-bar-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bar-right) > ha-card#container > #content,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-lozenge-right > ha-card#container > #content,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-lozenge-right#container > #content,
+      ha-card.button-bullet-left > ha-card#container > #content,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bullet-left#container > #content,
+      ha-card.button-bullet-right > ha-card#container > #content,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bullet-right#container > #content,
+      ha-card.button-capped-left > ha-card#container > #content,
+      ha-card.button-capped-left > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-capped-left#container > #content,
+      ha-card.button-capped-right > ha-card#container > #content,
+      ha-card.button-capped-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-capped-right#container > #content,
+      ha-card.button-barrel-left > ha-card#container > #content,
+      ha-card.button-barrel-left > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-barrel-left#container > #content,
+      ha-card.button-barrel-right > ha-card#container > #content,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-barrel-right#container > #content,
+      ha-card.button-bar-left > ha-card#container > #content,
+      ha-card.button-bar-left > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-left#container > #content,
+      ha-card.button-bar-right > ha-card#container > #content,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-right#container > #content {
+        padding-left: calc(var(--lcars-vertical-border) + 18px);
+        justify-content: right;
+      }
+
+      :host(.button-lozenge-right) > ha-card#container,
+      :host(.button-lozenge-right) > ha-card,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card,
+      :host(.button-bullet-right) > ha-card#container,
+      :host(.button-bullet-right) > ha-card,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card,
+      :host(.button-capped-right) > ha-card#container,
+      :host(.button-capped-right) > ha-card,
+      :host(.button-capped-right) > #aspect-ratio > ha-card,
+      :host(.button-barrel-right) > ha-card#container,
+      :host(.button-barrel-right) > ha-card,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card,
+      ha-card.button-bullet-right > ha-card#container,
+      ha-card.button-bullet-right > ha-card,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card,
+      ha-card.button-bullet-right,
+      ha-card.button-capped-right > ha-card#container,
+      ha-card.button-capped-right > ha-card,
+      ha-card.button-capped-right > #aspect-ratio > ha-card,
+      ha-card.button-capped-right,
+      ha-card.button-barrel-right > ha-card#container,
+      ha-card.button-barrel-right > ha-card,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card,
+      ha-card.button-barrel-right {
+        align-items: flex-start;
+      }
+
+      :host(.button-lozenge-right) > ha-card#container > ha-state-icon,
+      :host(.button-lozenge-right) > ha-card > ha-state-icon,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bullet-right) > ha-card#container > ha-state-icon,
+      :host(.button-bullet-right) > ha-card > ha-state-icon,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-capped-right) > ha-card#container > ha-state-icon,
+      :host(.button-capped-right) > ha-card > ha-state-icon,
+      :host(.button-capped-right) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-barrel-right) > ha-card#container > ha-state-icon,
+      :host(.button-barrel-right) > ha-card > ha-state-icon,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bullet-right > ha-card#container > ha-state-icon,
+      ha-card.button-bullet-right > ha-card > ha-state-icon,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bullet-right > ha-state-icon,
+      ha-card.button-capped-right > ha-card#container > ha-state-icon,
+      ha-card.button-capped-right > ha-card > ha-state-icon,
+      ha-card.button-capped-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-capped-right > ha-state-icon,
+      ha-card.button-barrel-right > ha-card#container > ha-state-icon,
+      ha-card.button-barrel-right > ha-card > ha-state-icon,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-barrel-right > ha-state-icon {
+        left: auto;
+        right: 0;
+        border-right: 0px;
+        border-left: var(--lcars-background-color) solid 6px;
+      }
+
+      :host(.button-lozenge-right) > ha-card#container > span,
+      :host(.button-lozenge-right) > ha-card > span,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
+      :host(.button-bullet-right) > ha-card#container > span,
+      :host(.button-bullet-right) > ha-card > span,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
+      :host(.button-capped-right) > ha-card#container > span,
+      :host(.button-capped-right) > ha-card > span,
+      :host(.button-capped-right) > #aspect-ratio > ha-card > span,
+      :host(.button-barrel-right) > ha-card#container > span,
+      :host(.button-barrel-right) > ha-card > span,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-right > ha-card#container > span,
+      ha-card.button-bullet-right > ha-card > span,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-right > span,
+      ha-card.button-capped-right > ha-card#container > span,
+      ha-card.button-capped-right > ha-card > span,
+      ha-card.button-capped-right > #aspect-ratio > ha-card > span,
+      ha-card.button-capped-right > span,
+      ha-card.button-barrel-right > ha-card#container > span,
+      ha-card.button-barrel-right > ha-card > span,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card > span,
+      ha-card.button-barrel-right > span {
+        justify-content: flex-start;
+        left: var(--lcars-vertical-border);
+        padding-inline: 6px;
+      }
+
+      :host(.button-lozenge-right) > ha-card#container > #slider,
+      :host(.button-lozenge-right) > ha-card#container > #slider,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bullet-right) > ha-card#container > #slider,
+      :host(.button-bullet-right) > ha-card#container > #slider,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-capped-right) > ha-card#container > #slider,
+      :host(.button-capped-right) > ha-card#container > #slider,
+      :host(.button-capped-right) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-barrel-right) > ha-card#container > #slider,
+      :host(.button-barrel-right) > ha-card#container > #slider,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bullet-right > ha-card#container > #slider,
+      ha-card.button-bullet-right > ha-card#container > #slider,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bullet-right#container > #slider,
+      ha-card.button-capped-right > ha-card#container > #slider,
+      ha-card.button-capped-right > ha-card#container > #slider,
+      ha-card.button-capped-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-capped-right#container > #slider,
+      ha-card.button-barrel-right > ha-card#container > #slider,
+      ha-card.button-barrel-right > ha-card#container > #slider,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-barrel-right#container > #slider {
+        right: calc(var(--lcars-vertical-border) + 6px);
+        left: 0;
+        background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
+      }
+
+      :host(.button-lozenge-right) > ha-card#container > #content,
+      :host(.button-lozenge-right) > ha-card#container > #content,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bullet-right) > ha-card#container > #content,
+      :host(.button-bullet-right) > ha-card#container > #content,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-capped-right) > ha-card#container > #content,
+      :host(.button-capped-right) > ha-card#container > #content,
+      :host(.button-capped-right) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-barrel-right) > ha-card#container > #content,
+      :host(.button-barrel-right) > ha-card#container > #content,
+      :host(.button-barrel-right) > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bullet-right > ha-card#container > #content,
+      ha-card.button-bullet-right > ha-card#container > #content,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bullet-right#container > #content,
+      ha-card.button-capped-right > ha-card#container > #content,
+      ha-card.button-capped-right > ha-card#container > #content,
+      ha-card.button-capped-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-capped-right#container > #content,
+      ha-card.button-barrel-right > ha-card#container > #content,
+      ha-card.button-barrel-right > ha-card#container > #content,
+      ha-card.button-barrel-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-barrel-right#container > #content {
+        padding-left: var(--ha-card-border-radius);
+        padding-right: 0px;
+        justify-content: left;
+      }
+
+      :host(.button-lozenge-left) > ha-card#container,
+      :host(.button-lozenge-left) > ha-card,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card,
+      :host(.button-lozenge-right) > ha-card#container,
+      :host(.button-lozenge-right) > ha-card,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card,
+      :host(.button-bullet-left) > ha-card#container,
+      :host(.button-bullet-left) > ha-card,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card,
+      :host(.button-capped-right) > ha-card#container,
+      :host(.button-capped-right) > ha-card,
+      :host(.button-capped-right) > #aspect-ratio > ha-card,
+      :host(.button-bar-left) > ha-card#container,
+      :host(.button-bar-left) > ha-card,
+      :host(.button-bar-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-right) > ha-card#container,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-bullet-left > ha-card#container,
+      ha-card.button-bullet-left > ha-card,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card,
+      ha-card.button-bullet-left,
+      ha-card.button-bar-left > ha-card#container,
+      ha-card.button-bar-left > ha-card,
+      ha-card.button-bar-left > #aspect-ratio > ha-card,
+      ha-card.button-bar-left,
+      ha-card.button-lozenge-right > ha-card#container,
+      ha-card.button-lozenge-right > ha-card,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-right,
+      ha-card.button-capped-right > ha-card#container,
+      ha-card.button-capped-right > ha-card,
+      ha-card.button-capped-right > #aspect-ratio > ha-card,
+      ha-card.button-capped-right,
+      ha-card.button-bar-right > ha-card#container,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        border-top-right-radius: var(--ha-card-border-radius);
+        border-bottom-right-radius: var(--ha-card-border-radius);
+      }
+
+      :host(.button-lozenge-left) > ha-card#container,
+      :host(.button-lozenge-left) > ha-card,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card,
+      :host(.button-lozenge-right) > ha-card#container,
+      :host(.button-lozenge-right) > ha-card,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card,
+      :host(.button-bullet-right) > ha-card#container,
+      :host(.button-bullet-right) > ha-card,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card,
+      :host(.button-capped-left) > ha-card#container,
+      :host(.button-capped-left) > ha-card,
+      :host(.button-capped-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-left) > ha-card#container,
+      :host(.button-bar-left) > ha-card,
+      :host(.button-bar-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-right) > ha-card#container,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-capped-left > ha-card#container,
+      ha-card.button-capped-left > ha-card,
+      ha-card.button-capped-left > #aspect-ratio > ha-card,
+      ha-card.button-capped-left,
+      ha-card.button-bar-left > ha-card#container,
+      ha-card.button-bar-left > ha-card,
+      ha-card.button-bar-left > #aspect-ratio > ha-card,
+      ha-card.button-bar-left,
+      ha-card.button-lozenge-right > ha-card#container,
+      ha-card.button-lozenge-right > ha-card,
+      ha-card.button-lozenge-right > #aspect-ratio > ha-card,
+      ha-card.button-lozenge-right,
+      ha-card.button-bullet-right > ha-card#container,
+      ha-card.button-bullet-right > ha-card,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card,
+      ha-card.button-bullet-right,
+      ha-card.button-bar-right > ha-card#container,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        border-top-left-radius: var(--ha-card-border-radius);
+        border-bottom-left-radius: var(--ha-card-border-radius);
+      }
+
+      :host(.button-lozenge-left) > ha-card#container > span,
+      :host(.button-lozenge-left) > ha-card > span,
+      :host(.button-lozenge-left) > #aspect-ratio > ha-card > span,
+      :host(.button-bullet-left) > ha-card#container > span,
+      :host(.button-bullet-left) > ha-card > span,
+      :host(.button-bullet-left) > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-left > ha-card#container > span,
+      ha-card.button-bullet-left > ha-card > span,
+      ha-card.button-bullet-left > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-left > span {
+        padding-right: var(--ha-card-border-radius);
+      }
+
+      :host(.button-lozenge-right) > ha-card#container > span,
+      :host(.button-lozenge-right) > ha-card > span,
+      :host(.button-lozenge-right) > #aspect-ratio > ha-card > span,
+      :host(.button-bullet-right) > ha-card#container > span,
+      :host(.button-bullet-right) > ha-card > span,
+      :host(.button-bullet-right) > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-right > ha-card#container > span,
+      ha-card.button-bullet-right > ha-card > span,
+      ha-card.button-bullet-right > #aspect-ratio > ha-card > span,
+      ha-card.button-bullet-right > span {
+        padding-left: var(--ha-card-border-radius);
+      }
+
+      :host(.button-bar-left) > ha-card#container,
+      :host(.button-bar-left) > ha-card,
+      :host(.button-bar-left) > #aspect-ratio > ha-card,
+      :host(.button-bar-right) > ha-card#container,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-bar-right > ha-card#container,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        line-height: 60px;
+        font-size: 60px;
+        padding-left: var(--lcars-vertical-border);
+        flex-direction: row;
+        justify-content: space-between;
+      }
+
+      :host(.button-bar-left) > ha-card#container > span,
+      :host(.button-bar-left) > ha-card > span,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > span,
+      :host(.button-bar-right) > ha-card#container > span,
+      :host(.button-bar-right) > ha-card > span,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span,
+      ha-card.button-bar-right > ha-card#container > span,
+      ha-card.button-bar-right > ha-card > span,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span,
+      ha-card.button-bar-right > span {
+        width: fit-content;
+        padding: 0px;
+      }
+
+      :host(.button-bar-left) > ha-card#container > span.state,
+      :host(.button-bar-left) > ha-card > span.state,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > span.state,
+      :host(.button-bar-right) > ha-card#container > span.state,
+      :host(.button-bar-right) > ha-card > span.state,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-right > ha-card#container > span.state,
+      ha-card.button-bar-right > ha-card > span.state,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-right > span.state {
+        padding-right: var(--ha-card-border-radius);
+        height: 100%;
+      }
+
+      :host(.button-bar-left) > ha-card#container > span:not(.state),
+      :host(.button-bar-left) > ha-card > span:not(.state),
+      :host(.button-bar-left) > #aspect-ratio > ha-card > span:not(.state),
+      :host(.button-bar-right) > ha-card#container > span:not(.state),
+      :host(.button-bar-right) > ha-card > span:not(.state),
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span:not(.state),
+      ha-card.button-bar-right > ha-card#container > span:not(.state),
+      ha-card.button-bar-right > ha-card > span:not(.state),
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span:not(.state),
+      ha-card.button-bar-right > span:not(.state) {
+        color: var(--lcars-background-text);
+        height: 100%;
+        background-color: var(--lcars-background-color);
+        padding-inline: 6px;
+        padding-bottom: 0.05em;
+        margin-top: -0.5em;
+      }
+
+      :host(.button-bar-left) > ha-card#container > ha-state-icon,
+      :host(.button-bar-left) > ha-card > ha-state-icon,
+      :host(.button-bar-left) > #aspect-ratio > ha-card > ha-state-icon,
+      :host(.button-bar-right) > ha-card#container > ha-state-icon,
+      :host(.button-bar-right) > ha-card > ha-state-icon,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-right > ha-card#container > ha-state-icon,
+      ha-card.button-bar-right > ha-card > ha-state-icon,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-right > ha-state-icon {
+        font-size: 0;
+      }
+
+      :host(.button-bar-left) > ha-card#container > #slider,
+      :host(.button-bar-left) > ha-card#container > #slider,
+      :host(.button-bar-left) > #aspect-ratio > ha-card#container > #slider,
+      :host(.button-bar-right) > ha-card#container > #slider,
+      :host(.button-bar-right) > ha-card#container > #slider,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-right > ha-card#container > #slider,
+      ha-card.button-bar-right > ha-card#container > #slider,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-right#container > #slider {
+        right: 0;
+        left: calc(var(--lcars-vertical-border) + 6px);
+        background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
+      }
+
+      :host(.button-bar-left) > ha-card#container > #content,
+      :host(.button-bar-left) > ha-card#container > #content,
+      :host(.button-bar-left) > #aspect-ratio > ha-card#container > #content,
+      :host(.button-bar-right) > ha-card#container > #content,
+      :host(.button-bar-right) > ha-card#container > #content,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-right > ha-card#container > #content,
+      ha-card.button-bar-right > ha-card#container > #content,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-right#container > #content {
+        position: relative;
+        padding-right: var(--ha-card-border-radius);
+        padding-left: 18px;
+        padding-bottom: 0.1em;
+        justify-content: left;
+      }
+
+      :host(.button-bar-right) > ha-card#container,
+      :host(.button-bar-right) > ha-card,
+      :host(.button-bar-right) > #aspect-ratio > ha-card,
+      ha-card.button-bar-right > ha-card#container,
+      ha-card.button-bar-right > ha-card,
+      ha-card.button-bar-right > #aspect-ratio > ha-card,
+      ha-card.button-bar-right {
+        flex-direction: row-reverse;
+        padding-left: 0;
+        padding-right: var(--lcars-vertical-border);
+      }
+
+      :host(.button-bar-right) > ha-card#container > span.state,
+      :host(.button-bar-right) > ha-card > span.state,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-right > ha-card#container > span.state,
+      ha-card.button-bar-right > ha-card > span.state,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > span.state,
+      ha-card.button-bar-right > span.state {
+        padding-left: var(--ha-card-border-radius);
+        padding-right: 0;
+      }
+
+      :host(.button-bar-right) > ha-card#container > ha-state-icon,
+      :host(.button-bar-right) > ha-card > ha-state-icon,
+      :host(.button-bar-right) > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-right > ha-card#container > ha-state-icon,
+      ha-card.button-bar-right > ha-card > ha-state-icon,
+      ha-card.button-bar-right > #aspect-ratio > ha-card > ha-state-icon,
+      ha-card.button-bar-right > ha-state-icon {
+        left: auto;
+        right: 0;
+        border-right: 0px;
+        border-left: var(--lcars-background-color) solid 6px;
+      }
+
+      :host(.button-bar-right) > ha-card#container > #slider,
+      :host(.button-bar-right) > ha-card#container > #slider,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-right > ha-card#container > #slider,
+      ha-card.button-bar-right > ha-card#container > #slider,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #slider,
+      ha-card.button-bar-right#container > #slider {
+        right: calc(var(--lcars-vertical-border) + 6px);
+        left: 0;
+        background: linear-gradient(90deg, var(--bsc-slider-color), var(--bsc-slider-color) var(--bsc-percent), transparent var(--bsc-percent), transparent 100%);
+      }
+
+      :host(.button-bar-right) > ha-card#container > #content,
+      :host(.button-bar-right) > ha-card#container > #content,
+      :host(.button-bar-right) > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-right > ha-card#container > #content,
+      ha-card.button-bar-right > ha-card#container > #content,
+      ha-card.button-bar-right > #aspect-ratio > ha-card#container > #content,
+      ha-card.button-bar-right#container > #content {
+        padding-left: var(--ha-card-border-radius);
+        padding-right: 18px;
+        justify-content: right;
+      }
+
       :host(.bar-left),
       :host(.bar-right),
       :host(.bar-large-left),
       :host(.bar-large-right),
-      ha-card:is(.bar-left,
-                 .bar-large-left,
-                 .bar-right,
-                 .bar-large-right
-      ):not(div > *)   {
+      :host > ha-card.bar-left,
+      :host > ha-card.bar-large-left,
+      :host > ha-card.bar-right,
+      :host > ha-card.bar-large-right {
         background-color: var(--lcars-card-top-color);
         --lcars-primary-text: var(--lcars-card-top-text) !important;
         border-radius: 9999px;
@@ -1216,181 +1684,180 @@
         font-size: 2em;
         line-height: 1;
         overflow:hidden;
-
-        > :not(style,card-mod,h1) {
-          text-transform: uppercase;
-          background-color: var(--lcars-background-color);
-          --lcars-primary-text: var(--lcars-background-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-          color: var(--primary-text-color);
-          border-radius: 0px;
-          display: inline-block;
-          padding: 0px 6px 0px 6px;
-          height: calc(100% + 0.4em);
-          vertical-align: top;
-          overflow: hidden;
-
-          > ha-markdown {
-            padding: 0px;
-            margin-top: -0.06em;
-          }
-        }
-
-        .title { 
-          font-size: inherit !important;
-          line-height: 1;
-          margin-top: -0.06em;
-        }
       }
-      
+
+      :host(.bar-left) > *:not(style):not(card-mod):not(h1),
+      :host(.bar-right) > *:not(style):not(card-mod):not(h1),
+      :host(.bar-large-left) > *:not(style):not(card-mod):not(h1),
+      :host(.bar-large-right) > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-large-left > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-right > *:not(style):not(card-mod):not(h1),
+      :host > ha-card.bar-large-right > *:not(style):not(card-mod):not(h1) {
+        text-transform: uppercase;
+        background-color: var(--lcars-background-color);
+        --lcars-primary-text: var(--lcars-background-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
+        color: var(--primary-text-color);
+        border-radius: 0px;
+        display: inline-block;
+        padding: 0px 6px 0px 6px;
+        height: calc(100% + 0.4em);
+        vertical-align: top;
+        overflow: hidden;
+      }
+
+      :host(.bar-left) > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host(.bar-right) > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host(.bar-large-left) > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host(.bar-large-right) > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-left > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-large-left > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-right > *:not(style):not(card-mod):not(h1) > ha-markdown,
+      :host > ha-card.bar-large-right > *:not(style):not(card-mod):not(h1) > ha-markdown {
+        padding: 0px;
+        margin-top: -0.06em;
+      }
+
+      :host(.bar-left) .title,
+      :host(.bar-right) .title,
+      :host(.bar-large-left) .title,
+      :host(.bar-large-right) .title,
+      :host > ha-card.bar-left .title,
+      :host > ha-card.bar-large-left .title,
+      :host > ha-card.bar-right .title,
+      :host > ha-card.bar-large-right .title {
+        font-size: inherit !important;
+        line-height: 1;
+        margin-top: -0.06em;
+      }
+
       :host(.bar-large-left),
       :host(.bar-large-right),
-      ha-card:is(.bar-large-left,
-                 .bar-large-right
-      ):not(div > *) {
-          font-size: 3em;
+      :host > ha-card.bar-large-left,
+      :host > ha-card.bar-large-right {
+        font-size: 3em;
       }
 
       :host(.bar-left),
       :host(.bar-large-left),
-      ha-card:is(.bar-left,
-                 .bar-large-left
-      ):not(div > *) {
+      :host > ha-card.bar-left,
+      :host > ha-card.bar-large-left {
         border-left: var(--lcars-vertical-border) solid var(--lcars-card-top-color);
       }
 
       :host(.bar-right),
       :host(.bar-large-right),
-      ha-card:is(.bar-right,
-                 .bar-large-right
-      ):not(div > *) {
+      :host > ha-card.bar-right,
+      :host > ha-card.bar-large-right {
         border-right: var(--lcars-vertical-border) solid var(--lcars-card-top-color);
         text-align: right;
       }
 
-      /* =============================================== */
-      /*               STACK STYLES                      */
-      /* =============================================== */
       :host(.type-vertical-stack),
       :host(.type-horizontal-stack) {
         position: relative;
-        .card-header {
-          padding: 0px;
-          position: absolute;
-          left: calc( 0px - var(--lcars-vertical-border) /2);
-          top: 50%;
-          transform: translate(-50%, -50%);
-          background-color: transparent;
-        }
       }
-      :host(.header-right.type-horizontal-stack),
-      :host(.middle-right.type-horizontal-stack),
-      :host(.footer-right.type-horizontal-stack),
-      :host(.header-right.type-vertical-stack),
-      :host(.middle-right.type-vertical-stack),
-      :host(.footer-right.type-vertical-stack) {
-        .card-header {
-          transform: translate(50%, -50%);
-          left: unset;
-          right: calc( 0px - var(--lcars-vertical-border) /2);
-        }
-      }
-      :host(.header-left.type-horizontal-stack),
-      :host(.header-right.type-horizontal-stack),
-      :host(.header-contained.type-horizontal-stack),
-      :host(.header-left.type-vertical-stack),
-      :host(.header-right.type-vertical-stack),
-      :host(.header-contained.type-vertical-stack) {
-        .card-header {
-          color: var(--lcars-card-top-text);
-        }
-      }
-      :host(.middle-left.type-horizontal-stack),
-      :host(.middle-right.type-horizontal-stack),
-      :host(.middle-contained.type-horizontal-stack),
-      :host(.middle-left.type-vertical-stack),
-      :host(.middle-right.type-vertical-stack),
-      :host(.middle-contained.type-vertical-stack) {
-        .card-header {
-          color: var(--lcars-card-mid-text);
-        }
-      }
-      :host(.footer-left.type-horizontal-stack),
-      :host(.footer-right.type-horizontal-stack),
-      :host(.footer-contained.type-horizontal-stack),
-      :host(.footer-left.type-vertical-stack),
-      :host(.footer-right.type-vertical-stack),
-      :host(.footer-contained.type-vertical-stack) {
-        .card-header {
-          color: var(--lcars-card-bottom-text);
-        }
-      }
-      
-      /* =============================================== */
-      /*               MISCELLANEOUS STYLES              */
-      /* =============================================== */
 
-      /* WIP fix for aliasing ugliness on slider tracks */
+      :host(.type-vertical-stack) .card-header,
+      :host(.type-horizontal-stack) .card-header {
+        padding: 0px;
+        position: absolute;
+        left: calc( 0px - var(--lcars-vertical-border) /2);
+        top: 50%;
+        transform: translate(-50%, -50%);
+        background-color: transparent;
+      }
+
+      :host(.header-right.type-horizontal-stack) .card-header,
+      :host(.middle-right.type-horizontal-stack) .card-header,
+      :host(.footer-right.type-horizontal-stack) .card-header,
+      :host(.header-right.type-vertical-stack) .card-header,
+      :host(.middle-right.type-vertical-stack) .card-header,
+      :host(.footer-right.type-vertical-stack) .card-header {
+        transform: translate(50%, -50%);
+        left: unset;
+        right: calc( 0px - var(--lcars-vertical-border) /2);
+      }
+
+      :host(.header-left.type-horizontal-stack) .card-header,
+      :host(.header-right.type-horizontal-stack) .card-header,
+      :host(.header-contained.type-horizontal-stack) .card-header,
+      :host(.header-left.type-vertical-stack) .card-header,
+      :host(.header-right.type-vertical-stack) .card-header,
+      :host(.header-contained.type-vertical-stack) .card-header {
+        color: var(--lcars-card-top-text);
+      }
+
+      :host(.middle-left.type-horizontal-stack) .card-header,
+      :host(.middle-right.type-horizontal-stack) .card-header,
+      :host(.middle-contained.type-horizontal-stack) .card-header,
+      :host(.middle-left.type-vertical-stack) .card-header,
+      :host(.middle-right.type-vertical-stack) .card-header,
+      :host(.middle-contained.type-vertical-stack) .card-header {
+        color: var(--lcars-card-mid-text);
+      }
+
+      :host(.footer-left.type-horizontal-stack) .card-header,
+      :host(.footer-right.type-horizontal-stack) .card-header,
+      :host(.footer-contained.type-horizontal-stack) .card-header,
+      :host(.footer-left.type-vertical-stack) .card-header,
+      :host(.footer-right.type-vertical-stack) .card-header,
+      :host(.footer-contained.type-vertical-stack) .card-header {
+        color: var(--lcars-card-bottom-text);
+      }
+
       .type-light > .bar {
         stroke-width: 5px;
       }
 
-      /* ----------------------------------------------- */
-      /*               Specific Card Fixes               */
-      /* ----------------------------------------------- */
-
-      /* ----------- Calendar Card --------------------- */
-      :host(.type-calendar),
-      ha-card:is(.type-calendar) {
-        ha-full-calendar {
-          --lcars-primary-text: var(--lcars-background-text) !important;
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
-          --ha-card-header-color: var(--lcars-primary-text);
-          --ha-color-text-primary: var(--lcars-primary-text);
-          --primary-text-color: var(--lcars-primary-text);
-          --secondary-text-color: var(--lcars-primary-text);
-          --text-primary-color: var(--lcars-primary-text);
-          --mdc-select-label-ink-color: var(--lcars-secondary-text);
-          --mdc-select-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-label-ink-color: var(--lcars-primary-text);
-          --mdc-text-field-fill-color: transparent;
-          --mdc-text-field-ink-color: var(--lcars-primary-text);
-          --wa-form-control-value-color: var(--lcars-primary-text);
-          --state-icon-color: var(--lcars-primary-text);
-          --card-primary-color: var(--lcars-primary-text);
-          --card-secondary-color: var(--lcars-secondary-text);
-        }
+      :host(.type-calendar) ha-full-calendar,
+      ha-card.type-calendar ha-full-calendar {
+        --lcars-primary-text: var(--lcars-background-text) !important;
+        --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
+        --ha-card-header-color: var(--lcars-primary-text);
+        --ha-color-text-primary: var(--lcars-primary-text);
+        --primary-text-color: var(--lcars-primary-text);
+        --secondary-text-color: var(--lcars-primary-text);
+        --text-primary-color: var(--lcars-primary-text);
+        --mdc-select-label-ink-color: var(--lcars-secondary-text);
+        --mdc-select-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-label-ink-color: var(--lcars-primary-text);
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-ink-color: var(--lcars-primary-text);
+        --wa-form-control-value-color: var(--lcars-primary-text);
+        --state-icon-color: var(--lcars-primary-text);
+        --card-primary-color: var(--lcars-primary-text);
+        --card-secondary-color: var(--lcars-secondary-text);
       }
 
-      /* ----------- HTML Template Card ---------------- */
-      :host, ha-card {
-        &:is(.type-custom-html-template-card, .type-custom-html-card) {
-          padding:0px !important;
-        }
+      :host.type-custom-html-template-card,
+      :host.type-custom-html-card,
+      ha-card.type-custom-html-template-card,
+      ha-card.type-custom-html-card {
+        padding:0px !important;
       }
 
-      /* ----------- Weather Card ---------------------- */
       :host(.type-custom-weather-card) > ha-card {
         padding-top: 12px !important;
       }
 
-      /* ----------- To-Do List Card ------------------- */
       :host(.type-todo-list),
-      ha-card:is(.type-todo-list) {
+      ha-card.type-todo-list {
         --lcars-type: "todo-list";
         --card-background-color: transparent !important;
         --ha-card-border-radius: 0px !important;
@@ -1400,144 +1867,176 @@
         --completed-text-color: var(--lcars-gray);
         --list-border-left: 0px;
         --list-border-right: 0px;
-
-        > ha-card, &:is(ha-card) {
-          div.addRow {
-            background-color: var(--lcars-card-bottom-color);
-            --mdc-text-field-fill-color: var(--lcars-card-bottom-color);
-            color: var(--lcars-card-bottom-text);
-            --mdc-text-field-ink-color: var(--lcars-card-bottom-text);
-            --mdc-text-field-label-ink-color: var(--lcars-card-bottom-text);
-            caret-color: currentColor;
-            border-top-left-radius: var(--list-border-left);
-            border-top-right-radius: var(--list-border-right);
-            border-bottom-left-radius: var(--list-border-left);
-            border-bottom-right-radius: var(--list-border-right);
-            margin-block: 5px;
-            padding: 5px max(15px, var(--list-border-right)) 5px max(15px, var(--list-border-left));
-            height: 50px;
-          }
-          ha-sortable > ha-list {
-            .header {
-              background-color: var(--lcars-card-top-color);
-              color: var(--lcars-card-top-text);
-              --primary-text-color: var(--lcars-card-top-text);
-              border-top-left-radius: var(--list-border-left);
-              border-top-right-radius: var(--list-border-right);
-              border-bottom-left-radius: var(--list-border-left);
-              border-bottom-right-radius: var(--list-border-right);
-              margin-block: 5px;
-              height: 60px;
-              padding: 0px max(15px, var(--list-border-right)) 0px max(15px, var(--list-border-left));
-              font-size: 1.2rem;
-
-              h2 {
-                padding-bottom: 0.15em;
-              }
-            }
-
-            ha-check-list-item {
-              --check-border-right: 5px;
-              --check-border-left: 0px;
-              --flex-left: 1;
-
-              background-color: var(--active-color);
-              color: var(--active-text-color);
-              text-transform: uppercase;
-              display: flex;
-              flex-direction: row;
-              justify-content: space-between;
-              border-top-left-radius: var(--list-border-left);
-              border-top-right-radius: var(--list-border-right);
-              border-bottom-left-radius: var(--list-border-left);
-              border-bottom-right-radius: var(--list-border-right);
-              margin: 5px;
-              padding-top: 0px var(--list-border-right) 0px var(--list-border-left);
-              height: 60px;
-            }
-            ha-check-list-item.completed {
-              background-color: var(--completed-color);
-              color: var(--completed-text-color);
-            }
-            ha-check-list-item.completed ha-svg-icon {
-              background-color: var(--completed-text-color);
-            }
-            ha-check-list-item .mdc-checkbox {
-              opacity: 1;
-              position: absolute;
-            }
-            .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~
-            .mdc-checkbox__background, .mdc-checkbox
-            .mdc-checkbox__native-control:enabled:indeterminate ~
-            .mdc-checkbox__background, .mdc-checkbox
-            .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~
-            .mdc-checkbox__background {
-              border-color: var(--lcars-background-color);
-              background-color: var(--lcars-background-color);
-            }
-            ha-check-list-item .summary {
-              font-size: 1.2rem;
-              position: absolute;
-              right: max(8px, var(--list-border-right));
-              bottom: 8px;
-            }
-          }
-        }
       }
+
+      :host(.type-todo-list) > ha-card div.addRow,
+      ha-card.type-todo-list > ha-card div.addRow,
+      ha-card.type-todo-list div.addRow {
+        background-color: var(--lcars-card-bottom-color);
+        --mdc-text-field-fill-color: var(--lcars-card-bottom-color);
+        color: var(--lcars-card-bottom-text);
+        --mdc-text-field-ink-color: var(--lcars-card-bottom-text);
+        --mdc-text-field-label-ink-color: var(--lcars-card-bottom-text);
+        caret-color: currentColor;
+        border-top-left-radius: var(--list-border-left);
+        border-top-right-radius: var(--list-border-right);
+        border-bottom-left-radius: var(--list-border-left);
+        border-bottom-right-radius: var(--list-border-right);
+        margin-block: 5px;
+        padding: 5px max(15px, var(--list-border-right)) 5px max(15px, var(--list-border-left));
+        height: 50px;
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list .header,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list .header,
+      ha-card.type-todo-list ha-sortable > ha-list .header {
+        background-color: var(--lcars-card-top-color);
+        color: var(--lcars-card-top-text);
+        --primary-text-color: var(--lcars-card-top-text);
+        border-top-left-radius: var(--list-border-left);
+        border-top-right-radius: var(--list-border-right);
+        border-bottom-left-radius: var(--list-border-left);
+        border-bottom-right-radius: var(--list-border-right);
+        margin-block: 5px;
+        height: 60px;
+        padding: 0px max(15px, var(--list-border-right)) 0px max(15px, var(--list-border-left));
+        font-size: 1.2rem;
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list .header h2,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list .header h2,
+      ha-card.type-todo-list ha-sortable > ha-list .header h2 {
+        padding-bottom: 0.15em;
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item,
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item {
+        --check-border-right: 5px;
+        --check-border-left: 0px;
+        --flex-left: 1;
+        background-color: var(--active-color);
+        color: var(--active-text-color);
+        text-transform: uppercase;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        border-top-left-radius: var(--list-border-left);
+        border-top-right-radius: var(--list-border-right);
+        border-bottom-left-radius: var(--list-border-left);
+        border-bottom-right-radius: var(--list-border-right);
+        margin: 5px;
+        padding-top: 0px var(--list-border-right) 0px var(--list-border-left);
+        height: 60px;
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item.completed,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item.completed,
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item.completed {
+        background-color: var(--completed-color);
+        color: var(--completed-text-color);
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon,
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item.completed ha-svg-icon {
+        background-color: var(--completed-text-color);
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item .mdc-checkbox,
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item .mdc-checkbox {
+        opacity: 1;
+        position: absolute;
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background,
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:checked ~ .mdc-checkbox__background,
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control:enabled:indeterminate ~ .mdc-checkbox__background,
+      ha-card.type-todo-list ha-sortable > ha-list .mdc-checkbox .mdc-checkbox__native-control[data-indeterminate="true"]:enabled ~ .mdc-checkbox__background {
+        border-color: var(--lcars-background-color);
+        background-color: var(--lcars-background-color);
+      }
+
+      :host(.type-todo-list) > ha-card ha-sortable > ha-list ha-check-list-item .summary,
+      ha-card.type-todo-list > ha-card ha-sortable > ha-list ha-check-list-item .summary,
+      ha-card.type-todo-list ha-sortable > ha-list ha-check-list-item .summary {
+        font-size: 1.2rem;
+        position: absolute;
+        right: max(8px, var(--list-border-right));
+        bottom: 8px;
+      }
+
       :host(.list-lozenge-left),
       :host(.list-lozenge-right),
       :host(.list-bullet-right),
       :host(.list-capped-left),
-      ha-card:is(.list-lozenge-left),
-      ha-card:is(.list-lozenge-right),
-      ha-card:is(.list-bullet-right),
-      ha-card:is(.list-capped-left) {
+      ha-card.list-lozenge-left,
+      ha-card.list-lozenge-right,
+      ha-card.list-bullet-right,
+      ha-card.list-capped-left {
         --list-border-left: 30px;
         --left-border: 1;
       }
+
       :host(.list-lozenge-left),
       :host(.list-lozenge-right),
       :host(.list-bullet-left),
       :host(.list-capped-right),
-      ha-card:is(.list-lozenge-left),
-      ha-card:is(.list-lozenge-right),
-      ha-card:is(.list-bullet-left),
-      ha-card:is(.list-capped-right) {
+      ha-card.list-lozenge-left,
+      ha-card.list-lozenge-right,
+      ha-card.list-bullet-left,
+      ha-card.list-capped-right {
         --list-border-right: 30px;
         --right-border: 1;
       }
-      :host(.list-lozenge-right),
-      :host(.list-bullet-right),
-      :host(.list-capped-right),
-      :host(.list-barrel-right),
-      ha-card:is(.list-lozenge-right),
-      ha-card:is(.list-bullet-right),
-      ha-card:is(.list-capped-right),
-      ha-card:is(.list-barrel-right) {
-        & > ha-card, &:is(ha-card) {
-          > ha-sortable > ha-list > ha-check-list-item {
-            flex-direction: row-reverse;
-            --check-border-left: 5px;
-            --check-border-right: 0px;
-            --flex-left: 0;
-            --flex-right: 1;
 
-            .summary {
-              right: unset;
-              left: max(8px, var(--list-border-left));
-            }
-          }
-        }
+      :host(.list-lozenge-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      :host(.list-bullet-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      :host(.list-capped-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      :host(.list-barrel-right) > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-lozenge-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-lozenge-right > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-bullet-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-bullet-right > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-capped-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-capped-right > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-barrel-right > ha-card > ha-sortable > ha-list > ha-check-list-item,
+      ha-card.list-barrel-right > ha-sortable > ha-list > ha-check-list-item {
+        flex-direction: row-reverse;
+        --check-border-left: 5px;
+        --check-border-right: 0px;
+        --flex-left: 0;
+        --flex-right: 1;
       }
 
+      :host(.list-lozenge-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      :host(.list-bullet-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      :host(.list-capped-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      :host(.list-barrel-right) > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-lozenge-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-lozenge-right > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-bullet-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-bullet-right > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-capped-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-capped-right > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-barrel-right > ha-card > ha-sortable > ha-list > ha-check-list-item .summary,
+      ha-card.list-barrel-right > ha-sortable > ha-list > ha-check-list-item .summary {
+        right: unset;
+        left: max(8px, var(--list-border-left));
+      }
     # Gauge cards on various themes and styles need a background color
     "ha-card ha-gauge$": |
       .gauge {
         --primary-background-color: var(--lcars-dark-gray);
       }
-
     # To-Do List Card
-    "ha-card:has(ha-sortable)$": |
+    "ha-card$": |
       @container style(--lcars-type: "todo-list") {
         h1.card-header {
           background-color: var(--lcars-card-top-color);
@@ -1561,23 +2060,23 @@
           span {
             height: 100%;
             --mdc-list-item-graphic-margin: 0px;
+          }
+        }
 
-            ha-checkbox {
-              border-right: var(--check-border-right) solid var(--lcars-background-color);
-              border-left: var(--check-border-left) solid var(--lcars-background-color);
-              height: 100%;
-              display: flex;
-              align-items: center;
-
-              --mdc-checkbox-checked-color: var(--completed-color);
-
-              --right-shift: calc( var(--flex-left) * var(--left-border) );
-              --left-shift: calc( var(--flex-right) * var(--right-border) );
-              margin-right: calc( 0px - 5px * var(--right-shift) );
-              padding-left: calc( 5px * var(--right-shift) );
-              margin-left: calc( 0px - 5px * var(--left-shift) );
-              padding-right: calc( 5px * var(--left-shift) );
-            }
+        @container style(--lcars-type: "todo-list") {
+          span ha-checkbox {
+            border-right: var(--check-border-right) solid var(--lcars-background-color);
+            border-left: var(--check-border-left) solid var(--lcars-background-color);
+            height: 100%;
+            display: flex;
+            align-items: center;
+            --mdc-checkbox-checked-color: var(--completed-color);
+            --right-shift: calc( var(--flex-left) * var(--left-border) );
+            --left-shift: calc( var(--flex-right) * var(--right-border) );
+            margin-right: calc( 0px - 5px * var(--right-shift) );
+            padding-left: calc( 5px * var(--right-shift) );
+            margin-left: calc( 0px - 5px * var(--left-shift) );
+            padding-right: calc( 5px * var(--left-shift) );
           }
         }
     # Markdown h1 fix
@@ -1585,7 +2084,6 @@
       h1 {
         font-weight: normal;
       }
-
   # ===================================================== #
   #             Entities Cards Modifications              #
   # ===================================================== #
@@ -1593,60 +2091,63 @@
     .: |
       :host {
         --lcars-height: 60px;
-        /* Uses `lcars-readout-width` if the user specifies it in card_mod. Otherwise a global value is set, otherwise, vertical border, or a default value). */
         --lcars-global-readout-width: {{ states('sensor.lcars_readout_width') if has_value('sensor.lcars_readout_width') else 'unset' }};
         --lcars-inner-readout-width: var(--lcars-readout-width, var(--lcars-global-readout-width, var(--lcars-vertical-border, 150px)));
       }
-      /* Can't theme inside hui-generic-entity-row's dom from here */
-      /* So set variables to describe the behavior which are inherited into the dom */
+
       :host(.no-cap) {
         --lcars-capped: false;
       }
+
       :host(.entity-lozenge-left) {
         --lcars-entity-class: "entity-lozenge-left";
       }
+
       :host(.entity-bullet-left) {
         --lcars-entity-class: "entity-bullet-left";
       }
+
       :host(.entity-capped-left) {
         --lcars-entity-class: "entity-capped-left";
       }
+
       :host(.entity-barrel-left) {
         --lcars-entity-class: "entity-barrel-left";
       }
+
       :host(.entity-lozenge-right) {
         --lcars-entity-class: "entity-lozenge-right";
       }
+
       :host(.entity-bullet-right) {
         --lcars-entity-class: "entity-bullet-right";
       }
+
       :host(.entity-capped-right) {
         --lcars-entity-class: "entity-capped-right";
       }
+
       :host(.entity-barrel-right) {
         --lcars-entity-class: "entity-barrel-right";
       }
-      /* Handle row types that have a div outside the shadow dom */
-      /* .when and .what handle the event-type row */
-      /* .text-content handles the timer-type row */
-      /* .flex handles the number and input_number slider rows */
+
       @container style(--lcars-entity-class) {
         div:not(.what):not(.when):not(.text-content) {
           order: 1;
           box-sizing: border-box;
           padding: 0px 6px;
           min-width: var(--lcars-inner-readout-width);
-          @container style(--lcars-capped: false) {
-            min-width: calc(var(--lcars-inner-readout-width) + 40px);
-          }
         }
+      }
+
+      @container style(--lcars-entity-class) {
         div.flex {
           flex-grow: 0;
         }
       }
     "hui-generic-entity-row $": |
       @container style(--lcars-entity-class) {
-        state-badge{
+        state-badge {
           order: 0;
           background-color: var(--lcars-card-button-color);
           --state-icon-color: var(--lcars-card-button-text);
@@ -1657,6 +2158,9 @@
           border-bottom-left-radius: 0px;
           height: var(--lcars-height);
         }
+      }
+
+      @container style(--lcars-entity-class) {
         div.info.text-content {
           order: 2;
           background-color: var(--lcars-card-button-color);
@@ -1675,7 +2179,11 @@
           align-items: flex-end;
           justify-content: end;
         }
-        div.value.text-content, slot {
+      }
+
+      @container style(--lcars-entity-class) {
+        div.value.text-content,
+        slot {
           order: 1;
           background-color: transparent;
           --primary-text-color: var(--lcars-background-text);
@@ -1692,6 +2200,7 @@
           white-space: nowrap;
         }
       }
+
       @container style(--lcars-entity-class: "entity-lozenge-right") 
               or style(--lcars-entity-class: "entity-barrel-right") 
               or style(--lcars-entity-class: "entity-bullet-right")  
@@ -1699,20 +2208,32 @@
         state-badge {
           order: 2;
         }
+      }
+
+      @container style(--lcars-entity-class: "entity-lozenge-right") 
+              or style(--lcars-entity-class: "entity-barrel-right") 
+              or style(--lcars-entity-class: "entity-bullet-right")  
+              or style(--lcars-entity-class: "entity-capped-right") {
         div.info.text-content {
           order: 0;
           padding: 0px 3px 6px 12px;
           justify-content: start;
         }
-        div.value.text-content {
-          .state {
-            text-align: left;
-          }
+      }
+
+      @container style(--lcars-entity-class: "entity-lozenge-right") 
+              or style(--lcars-entity-class: "entity-barrel-right") 
+              or style(--lcars-entity-class: "entity-bullet-right")  
+              or style(--lcars-entity-class: "entity-capped-right") {
+        div.value.text-content .state {
+          text-align: left;
         }
       }
+
       :host {
         overflow: hidden;
       }
+
       @container style(--lcars-entity-class: "entity-lozenge-left") 
               or style(--lcars-entity-class: "entity-lozenge-right") 
               or style(--lcars-entity-class: "entity-bullet-left")  
@@ -1722,6 +2243,7 @@
           border-bottom-left-radius: 9999px;
         }
       }
+
       @container style(--lcars-entity-class: "entity-lozenge-left") 
               or style(--lcars-entity-class: "entity-lozenge-right") 
               or style(--lcars-entity-class: "entity-bullet-right")  
@@ -1731,13 +2253,20 @@
           border-bottom-right-radius: 9999px;
         }
       }
+
       @container style(--lcars-capped: false) {
         state-badge {
           display: none;
         }
+      }
+
+      @container style(--lcars-capped: false) {
         div.value.text-content {
           min-width: calc(var(--lcars-inner-readout-width) + 40px);
         }
+      }
+
+      @container style(--lcars-capped: false) {
         @container style(--lcars-entity-class: "entity-lozenge-left") 
                 or style(--lcars-entity-class: "entity-bullet-left") 
                 or style(--lcars-entity-class: "entity-barrel-left")  
@@ -1747,6 +2276,9 @@
             border-bottom-left-radius: 0;
           }
         }
+      }
+
+      @container style(--lcars-capped: false) {
         @container style(--lcars-entity-class: "entity-lozenge-right") 
                 or style(--lcars-entity-class: "entity-barrel-right") 
                 or style(--lcars-entity-class: "entity-bullet-right")  
@@ -1756,7 +2288,6 @@
             border-bottom-right-radius: 9999px;
           }
         }
-
       }
   # ===================================================== #
   #          TOOLBAR AND DASHBOARD MODIFICATIONS          #
@@ -1771,9 +2302,11 @@
         font-family: var(--font-family) !important;
         text-transform: uppercase;
       }
+
       .tab-group-top {
         --safe-track-width: 0px;
       }
+
       .tabs {
         overflow-y: hidden;
       }
@@ -1782,23 +2315,23 @@
         --track-width: 0px;
         --tab-bar-height: 48px;
         --ha-tab-padding-start: 5px;
-        --ha-tab-padding-end: 5px ;
+        --ha-tab-padding-end: 5px;
         flex: 1;
-
-        > div.tab {
-          border-right: 4px solid var(--lcars-background-color);
-          text-align: center;
-          display: block;
-          min-height: 40px;
-        }
       }
+
+      :host > div.tab {
+        border-right: 4px solid var(--lcars-background-color);
+        text-align: center;
+        display: block;
+        min-height: 40px;
+      }
+
       :host([aria-selected="true"]),
       :host([active]) {
         background-color: var(--lcars-ui-tertiary);
       }
     div.header: |
       .toolbar {
-        /* hack fix for rounding errors the cause slight gap between header and sidebar */
         box-shadow: -1px 0px var(--lcars-sidebar-background);
         color: var(--lcars-sidebar-text);
         background-color: var(--lcars-sidebar-background);
@@ -1807,85 +2340,88 @@
         border-radius: 0px 0px 0px 0px;
         margin-right: 1px;
         padding: 0px 12px !important;
+      }
 
-        /* -------- Sidebar Toggle -------- */
-        ha-menu-button {
-          display: none;
-          color: transparent;
-        }
-        @media screen and (max-width: 870px) {
-          ha-button-menu > ha-icon-button {
-            margin-right: -48px;
-            padding-right: unset !important;
-            margin-left: unset !important;
-          }
-          ha-icon-button {
-            padding-right: unset !important;
-            margin-left: unset !important;
-          }
-          ha-menu-button {
-            display: initial !important;
-            color: var(--lcars-ui-primary-text) !important;
-            padding-right: 0px !important;
-            margin-right: -22px;
-            margin-left: -16px;
-          }
-          .main-title
-          {
-            margin-left: 22px !important;
-          }
-        }
-        
-        /* -------- Inner elbow -------- */
-        &::before {
-          content: "";
-          position: fixed;
-          height: 40px;
-          width: 100px;
-          background-color: transparent;
-          border-top-left-radius: 40px;
-          box-shadow: -40px 0 0 0 var(--lcars-ui-primary);
-          margin-top: 80px;
-          margin-left: -12px;
-          z-index: 9997;
-          pointer-events: none;
-        }
+      .toolbar ha-menu-button {
+        display: none;
+        color: transparent;
+      }
 
-        /* -------- Clock -------- */
-        &::after {
-          content: "{{ states('sensor.lcars_header') if has_value('sensor.lcars_header') else states('sensor.time') if has_value('sensor.time') else 'LCARS' }}";
-          color: var(--lcars-ui-app-header-clock);
-          visibility: visible;
-          font-size: var(--header-font-size);
-          font-family: var(--font-family);
-          margin: 0px -12px 0px 0px;
-          padding: 0px 0px 0px 0px;
-          background-color: var(--lcars-background-color);
-          vertical-align: middle;
-          height: var(--header-height);
-          border-right: 5px solid var(--lcars-background-color);
-          border-left: 5px solid var(--lcars-background-color);
-          text-transform: uppercase;
-          white-space: nowrap;
-          line-height: 0.95;
-        }
-        @media screen and (max-width: 870px) {
-          &::after {
-            content: "";
-            border-left: 0px solid var(--lcars-background-color);
-          }
+      @media screen and (max-width: 870px) {
+        .toolbar ha-button-menu > ha-icon-button {
+          margin-right: -48px;
+          padding-right: unset !important;
+          margin-left: unset !important;
         }
       }
 
+      @media screen and (max-width: 870px) {
+        .toolbar ha-icon-button {
+          padding-right: unset !important;
+          margin-left: unset !important;
+        }
+      }
 
+      @media screen and (max-width: 870px) {
+        .toolbar ha-menu-button {
+          display: initial !important;
+          color: var(--lcars-ui-primary-text) !important;
+          padding-right: 0px !important;
+          margin-right: -22px;
+          margin-left: -16px;
+        }
+      }
+
+      @media screen and (max-width: 870px) {
+        .toolbar .main-title {
+          margin-left: 22px !important;
+        }
+      }
+
+      .toolbar::before {
+        content: "";
+        position: fixed;
+        height: 40px;
+        width: 100px;
+        background-color: transparent;
+        border-top-left-radius: 40px;
+        box-shadow: -40px 0 0 0 var(--lcars-ui-primary);
+        margin-top: 80px;
+        margin-left: -12px;
+        z-index: 9997;
+        pointer-events: none;
+      }
+
+      .toolbar::after {
+        content: "{{ states('sensor.lcars_header') if has_value('sensor.lcars_header') else states('sensor.time') if has_value('sensor.time') else 'LCARS' }}";
+        color: var(--lcars-ui-app-header-clock);
+        visibility: visible;
+        font-size: var(--header-font-size);
+        font-family: var(--font-family);
+        margin: 0px -12px 0px 0px;
+        padding: 0px 0px 0px 0px;
+        background-color: var(--lcars-background-color);
+        vertical-align: middle;
+        height: var(--header-height);
+        border-right: 5px solid var(--lcars-background-color);
+        border-left: 5px solid var(--lcars-background-color);
+        text-transform: uppercase;
+        white-space: nowrap;
+        line-height: 0.95;
+      }
+
+      @media screen and (max-width: 870px) {
+        .toolbar::after {
+          content: "";
+          border-left: 0px solid var(--lcars-background-color);
+        }
+      }
     div.edit-mode: |
-      /* =============================================== */
-      /*            EDIT MODE SETTINGS                   */
-      /* =============================================== */
       .tab-bar {
         background: var(--lcars-background-color);
         padding-left: 40px;
       }
+
       ha-tab-group {
         margin-left: 0px;
         border-left: none;
@@ -1893,34 +2429,32 @@
         color: var(--lcars-text-light);
         --icon-primary-color: var(--lcars-text-light);
       }
+
       #add-view {
         background-color: var(--lcars-card-top-color);
         height: 40px;
         border-radius: 0px 0px 0px 0px;
         border-left: solid var(--lcars-background-color) 4px;
       }
+
       div.main-title {
         color: var(--lcars-ui-primary-text);
-
-        .edit-icon {
-          color: var(--lcars-ui-primary-text) !important;
-        }
       }
+
+      div.main-title .edit-icon {
+        color: var(--lcars-ui-primary-text) !important;
+      }
+
       .exit-edit-mode {
         --wa-color-fill-normal: var(--lcars-ui-tertiary);
         --wa-color-on-normal: var(--lcars-text-light);
-        --button-color-fill-normal-hover:  color-mix(in srgb, var(--lcars-ui-tertiary), black 30%);;
+        --button-color-fill-normal-hover:  color-mix(in srgb, var(--lcars-ui-tertiary), black 30%);
       }
+
       .toolbar .action-items {
         --text-primary-color: var(--lcars-ui-primary-text);
       }
-
-
     .: |
-      /* =============================================== */
-      /*            VIEW AND PANEL SETTINGS              */
-      /* =============================================== */
-
       hui-view {
         container-type: inline-size;
         container-name: view-container;
@@ -1928,7 +2462,7 @@
 
       hui-panel-view {
         overflow: hidden;
-      }      
+      }
 
       @container view-container (min-width: 0px) {
         hui-panel-view {
@@ -1944,6 +2478,7 @@
           padding: 0px 0px 0px 0px !important;
         }
       }
+
       #view {
         --primary-background-color: var(--primary-background-color);
         --lovelace-background: var(--primary-background-color);
@@ -1954,12 +2489,15 @@
         --lcars-sound: {{ true if is_state('input_boolean.lcars_sound', 'on') else false }};
         --lcars-texture: {{ true if is_state('input_boolean.lcars_texture', 'on') else false }};
       }
+
       hui-view::-webkit-scrollbar {
         display: none;
       }
+
       hui-view {
         scrollbar-width: none !important;
       }
+
       hui-masonry-view {
         padding-right: 23px;
       }
@@ -1973,18 +2511,12 @@
         --lcars-sound: true;
       }
       {% endif %}
-
   # ===================================================== #
   #                 CONFIG MODIFICATIONS                  #
   # ===================================================== #
   card-mod-config-yaml: &card-mod-config |
     .: |
       :host {
-        /* Force these to be recomputed to prevent eager variable resolution    */
-        /* There are too many places in the settings pages that use light and   */
-        /* dark font on various background colors. We can't track them all.     */
-        /* The solution is to use a medium luminance background and default     */
-        /* to light text. Some places will use black, but that's still legible. */
         --lcars-primary-text: var(--lcars-text-light);
         --lcars-secondary-text: var(--lcars-text-light);
         --primary-text-color: var(--lcars-primary-text);
@@ -2005,50 +2537,31 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
       }
-      ha-panel-config{
-        &::before {
-          @media screen and (min-width: 601px) {
-            content: "";
-            position: fixed;
-            height: 40px;
-            width: 100px;
-            background-color: transparent;
-            border-top-left-radius: 40px;
-            box-shadow: -40px 0 0 0 var(--lcars-ui-primary);
-            margin-top: 40px;
-            margin-left: 0px;
-            z-index: 5;
-            pointer-events: none;
-          }
-        }
-      }
-
     # ------------------- Dev Tools Submenu ---------------------------------- #
     "ha-panel-developer-tools $": |
       .header ha-tab-group {
         background-color: var(--lcars-background-color);
-        border-top-left-radius: var(--lcars-inner-radius);
+        border-top-left-radius: var(--lcars-inner-radius) !important;
         --track-width: unset;
-
-        ha-tab-group-tab {
-          border-radius: 99px;
-          background-color: var(--lcars-card-button-color);
-          color: var(--lcars-card-button-text);
-          margin: 10px 10px 0px 10px;
-          padding-left: 40px;
-        }
-
-        ha-tab-group-tab[active] {
-          background-color: var(--lcars-ui-tertiary);
-          border-bottom: 0px;
-          margin-bottom: 0px;
-        }
-        
       }
+
+      .header ha-tab-group ha-tab-group-tab {
+        border-radius: 99px;
+        background-color: var(--lcars-card-button-color);
+        color: var(--lcars-card-button-text);
+        margin: 10px 10px 0px 10px;
+        padding-left: 40px;
+      }
+
+      .header ha-tab-group ha-tab-group-tab[active] {
+        background-color: var(--lcars-ui-tertiary);
+        border-bottom: 0px;
+        margin-bottom: 0px;
+      }
+
       developer-tools-router {
         padding-top: 112px !important;
       }
-
     # ------------------- Bottom Nav Menu Fixes ------------------------------ #
     # Disappointingly, "* $ hass-tabs-subpage $" doesn't seem to work?
     # So I have to enumerate anywhere the bottom bar nav appears
@@ -2132,32 +2645,32 @@
           margin-top: 32px !important;
         }
       "ha-config-navigation-list $": |
-        ha-list-nav {
-        
-          ha-list-item-button {
-            background-color: var(--lcars-card-mid-color);
-            --primary-text-color: var(--lcars-card-mid-text);
-            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-            border-radius: 999px;
-            margin-block: 5px;
-          }
-          ha-list-item-button:first-child {
-            background-color: var(--lcars-card-top-color);
-            --primary-text-color: var(--lcars-card-top-text);
-            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-          }
-          ha-list-item-button:last-child {
-            background-color: var(--lcars-card-bottom-color);
-            --primary-text-color: var(--lcars-card-bottom-text);
-            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-          }
+        ha-list-nav ha-list-item-button {
+          background-color: var(--lcars-card-mid-color);
+          --primary-text-color: var(--lcars-card-mid-text);
+          --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
+          border-radius: 999px;
+          margin-block: 5px;
+        }
+
+        ha-list-nav ha-list-item-button:first-child {
+          background-color: var(--lcars-card-top-color);
+          --primary-text-color: var(--lcars-card-top-text);
+          --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
+        }
+
+        ha-list-nav ha-list-item-button:last-child {
+          background-color: var(--lcars-card-bottom-color);
+          --primary-text-color: var(--lcars-card-bottom-text);
+          --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
         }
     "ha-config-dashboard $ ha-top-app-bar-fixed ha-config-section":
       .: |
-        ha-card:has(ha-config-repairs) {
+        ha-card {
           --lcars-alert-color: var(--lcars-alert-red);
         }
-        ha-card:has(ha-config-updates) {
+
+        ha-card {
           --lcars-alert-color: var(--lcars-alert-yellow);
         }
       "ha-card":
@@ -2176,45 +2689,42 @@
             border-bottom-right-radius: 25px;
           }
         "ha-config-navigation $ ha-config-navigation-list$": | 
-          /* -------- Settings Page Lists -------- */
-          ha-list-nav {
-            ha-list-item-button {
-              background-color: var(--lcars-card-mid-color);
-              --primary-text-color: var(--lcars-card-mid-text);
-              --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-              border-radius: 999px;
-              margin-block: 5px;
-            }
-            ha-list-item-button:first-child {
-              background-color: var(--lcars-card-top-color);
-              --primary-text-color: var(--lcars-card-top-text);
-              --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-            }
-            ha-list-item-button:last-child {
-              background-color: var(--lcars-card-bottom-color);
-              --primary-text-color: var(--lcars-card-bottom-text);
-              --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
-            }
+          ha-list-nav ha-list-item-button {
+            background-color: var(--lcars-card-mid-color);
+            --primary-text-color: var(--lcars-card-mid-text);
+            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
+            border-radius: 999px;
+            margin-block: 5px;
+          }
+
+          ha-list-nav ha-list-item-button:first-child {
+            background-color: var(--lcars-card-top-color);
+            --primary-text-color: var(--lcars-card-top-text);
+            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
+          }
+
+          ha-list-nav ha-list-item-button:last-child {
+            background-color: var(--lcars-card-bottom-color);
+            --primary-text-color: var(--lcars-card-bottom-text);
+            --secondary-text-color: color-mix(in oklch, var(--primary-text-color) 80%, transparent);
           }
         "ha-config-repairs$": |
-          /* -------- Settings Page Repairs List -------- */
           ha-list-base {
             padding-block: 5px;
+          }
 
-            ha-list-item-button {
-              background-color: color-mix(in srgb, var(--lcars-alert-red), transparent 66%);
-              margin: 5px 30px;
-            }
+          ha-list-base ha-list-item-button {
+            background-color: color-mix(in srgb, var(--lcars-alert-red), transparent 66%);
+            margin: 5px 30px;
           }
         "ha-config-updates$": |
-          /* -------- Settings Page Updates List -------- */
           ha-list-base {
             padding-block: 5px;
+          }
 
-            ha-list-item-button {
-              background-color: color-mix(in srgb, var(--lcars-alert-yellow), transparent 66%);
-              margin: 5px 30px;
-            }
+          ha-list-base ha-list-item-button {
+            background-color: color-mix(in srgb, var(--lcars-alert-yellow), transparent 66%);
+            margin: 5px 30px;
           }
         "$": |
           :host {
@@ -2227,7 +2737,6 @@
     "ha-config-section-updates $ hass-subpage div.content":
       "ha-card":
         "$": |
-          /* -------- Updates Page List -------- */
           :host {
             background-color: transparent !important;
             --primary-text-color: var(--lcars-background-text);
@@ -2236,7 +2745,7 @@
             margin-top: 32px !important;
           }
         .: |
-          .title{
+          .title {
             text-transform: uppercase;
             font-size: 30px !important;
             line-height: 1;
@@ -2250,20 +2759,18 @@
             border-bottom-right-radius: 25px;
           }
         "div.card-content ha-config-updates$": |
-            
             ha-list-base {
               --md-sys-color-surface: transparent !important;
               padding-block: 5px;
+            }
 
-              ha-list-item-button {
-                background-color: color-mix(in srgb, var(--lcars-alert-yellow), transparent 66%);
-                margin: 5px 30px;
-              }
+            ha-list-base ha-list-item-button {
+              background-color: color-mix(in srgb, var(--lcars-alert-yellow), transparent 66%);
+              margin: 5px 30px;
             }
     "ha-config-repairs-dashboard $ hass-subpage div.content":
       "ha-card":
         "$": |
-          /* -------- Repairs Page List -------- */
           :host {
             background-color: transparent !important;
             --primary-text-color: var(--lcars-background-text);
@@ -2272,7 +2779,7 @@
             margin-top: 32px !important;
           }
         .: |
-          .title{
+          .title {
             text-transform: uppercase;
             font-size: 30px !important;
             line-height: 1;
@@ -2289,26 +2796,27 @@
           ha-list-base {
             --md-sys-color-surface: transparent !important;
             padding-block: 5px;
+          }
 
-            ha-list-item-button {
-              background-color: color-mix(in srgb, var(--lcars-alert-red), transparent 66%);
-              margin: 5px 30px;
-            }
+          ha-list-base ha-list-item-button {
+            background-color: color-mix(in srgb, var(--lcars-alert-red), transparent 66%);
+            margin: 5px 30px;
           }
     "ha-config-logs $ hass-subpage div search-input.header $ ha-textfield$": |
       label.mdc-text-field--filled {
         height: var(--header-height);
+      }
 
-        span#label {
-          line-height: 1.25rem;
-        }
-        input.mdc-text-field__input {
-          align-self: end;
-        }
+      label.mdc-text-field--filled span#label {
+        line-height: 1.25rem;
+      }
+
+      label.mdc-text-field--filled input.mdc-text-field__input {
+        align-self: end;
       }
     "ha-config-info $ hass-subpage div.content":
       "ha-card": |
-        :is(.header) {
+        .header {
           border-top: var(--lcars-horizontal-border) solid var(--lcars-card-top-color);
           border-inline: var(--lcars-vertical-border) solid var(--lcars-card-top-color);
           border-top-left-radius: var(--lcars-outer-radius);
@@ -2317,41 +2825,42 @@
           border-bottom-right-radius: 0px;
           background-color: transparent;
           --lcars-primary-text: var(--lcars-text-light);
-          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color))
-
-
-          &::before {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            height: calc(2 * var(--lcars-inner-radius) + 2px);
-            width: calc(2 * var(--lcars-inner-radius) + 2px);
-            background-color: transparent;
-            border-top-left-radius: var(--lcars-inner-radius);
-            box-shadow: calc(var(--lcars-inner-radius) * -1) 0 0 0 var(--lcars-card-top-color);
-            margin-top: 0px;
-            margin-left: 0px;
-            z-index: 5;
-            pointer-events: none;
-          }
-          &::after {
-            content: "";
-            position: absolute;
-            top: 0;
-            right: 0;
-            height: calc(2 * var(--lcars-inner-radius) + 2px);
-            width: calc(2 * var(--lcars-inner-radius) + 2px);
-            background-color: transparent;
-            border-top-right-radius: var(--lcars-inner-radius);
-            box-shadow: calc(var(--lcars-inner-radius)) 0 0 0 var(--lcars-card-top-color);
-            margin-top: 0px;
-            margin-right: 0px;
-            z-index: 5;
-            pointer-events: none;
-          }
+          --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
         }
-        :is(.ohf) {
+
+        .header::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: calc(2 * var(--lcars-inner-radius) + 2px);
+          width: calc(2 * var(--lcars-inner-radius) + 2px);
+          background-color: transparent;
+          border-top-left-radius: var(--lcars-inner-radius) !important;
+          box-shadow: calc(var(--lcars-inner-radius) * -1) 0 0 0 var(--lcars-card-top-color);
+          margin-top: 0px;
+          margin-left: 0px;
+          z-index: 5;
+          pointer-events: none;
+        }
+
+        .header::after {
+          content: "";
+          position: absolute;
+          top: 0;
+          right: 0;
+          height: calc(2 * var(--lcars-inner-radius) + 2px);
+          width: calc(2 * var(--lcars-inner-radius) + 2px);
+          background-color: transparent;
+          border-top-right-radius: var(--lcars-inner-radius) !important;
+          box-shadow: calc(var(--lcars-inner-radius)) 0 0 0 var(--lcars-card-top-color);
+          margin-top: 0px;
+          margin-right: 0px;
+          z-index: 5;
+          pointer-events: none;
+        }
+
+        .ohf {
           border-bottom: var(--lcars-horizontal-border) solid var(--lcars-card-bottom-color);
           border-inline: var(--lcars-vertical-border) solid var(--lcars-card-bottom-color);
           border-bottom-left-radius: var(--lcars-outer-radius);
@@ -2362,82 +2871,79 @@
           --lcars-primary-text: var(--lcars-background-text);
           --lcars-secondary-text: color-mix(in oklch, var(--lcars-primary-text) 80%, var(--lcars-ui-mix-color));
           margin-bottom: 6px;
-
-          &::before {
-            content: "";
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            height: calc(2 * var(--lcars-inner-radius) + 2px);
-            width: calc(2 * var(--lcars-inner-radius) + 2px);
-            background-color: transparent;
-            border-bottom-left-radius: var(--lcars-inner-radius);
-            box-shadow: calc(var(--lcars-inner-radius) * -1) 0 0 0 var(--lcars-card-bottom-color);
-            margin-top: 0px;
-            margin-left: 0px;
-            z-index: 5;
-            pointer-events: none;
-          }
-          &::after {
-            content: "";
-            position: absolute;
-            bottom: 0;
-            right: 0;
-            height: calc(2 * var(--lcars-inner-radius) + 2px);
-            width: calc(2 * var(--lcars-inner-radius) + 2px);
-            background-color: transparent;
-            border-bottom-right-radius: var(--lcars-inner-radius);
-            box-shadow: calc(var(--lcars-inner-radius)) 0 0 0 var(--lcars-card-bottom-color);
-            margin-top: 0px;
-            margin-right: 0px;
-            z-index: 5;
-            pointer-events: none;
-          }
-
         }
-        :is(.pages) {
+
+        .ohf::before {
+          content: "";
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          height: calc(2 * var(--lcars-inner-radius) + 2px);
+          width: calc(2 * var(--lcars-inner-radius) + 2px);
+          background-color: transparent;
+          border-bottom-left-radius: var(--lcars-inner-radius);
+          box-shadow: calc(var(--lcars-inner-radius) * -1) 0 0 0 var(--lcars-card-bottom-color);
+          margin-top: 0px;
+          margin-left: 0px;
+          z-index: 5;
+          pointer-events: none;
+        }
+
+        .ohf::after {
+          content: "";
+          position: absolute;
+          bottom: 0;
+          right: 0;
+          height: calc(2 * var(--lcars-inner-radius) + 2px);
+          width: calc(2 * var(--lcars-inner-radius) + 2px);
+          background-color: transparent;
+          border-bottom-right-radius: var(--lcars-inner-radius);
+          box-shadow: calc(var(--lcars-inner-radius)) 0 0 0 var(--lcars-card-bottom-color);
+          margin-top: 0px;
+          margin-right: 0px;
+          z-index: 5;
+          pointer-events: none;
+        }
+
+        .pages {
           background-color: transparent !important;
           --primary-text-color: var(--lcars-background-text);
           --secondary-text-color: var(--lcars-background-text);
           border-radius: 0 !important;
           margin-top: 6px !important;
           padding: 0px;
-
-          ha-md-list {
-            --md-sys-color-surface: transparent !important;
-            padding-top: 0px;
-          
-            ha-md-list-item {
-              background-color: var(--lcars-card-mid-color);
-              --md-list-item-label-text-color: var(--lcars-card-mid-text);
-              --md-list-item-supporting-text-color: var(--lcars-card-mid-text);
-              border-radius: 999px;
-              margin-block: 5px;
-            }
-            ha-md-list-item:first-child {
-              background-color: var(--lcars-card-top-color);
-              --md-list-item-label-text-color: var(--lcars-card-top-text);
-              --md-list-item-supporting-text-color: var(--lcars-card-top-text);
-            }
-            ha-md-list-item:last-child {
-              background-color: var(--lcars-card-bottom-color);
-              --md-list-item-label-text-color: var(--lcars-card-bottom-text);
-              --md-list-item-supporting-text-color: var(--lcars-card-bottom-text);
-            }
-          }
         }
 
+        .pages ha-md-list {
+          --md-sys-color-surface: transparent !important;
+          padding-top: 0px;
+        }
+
+        .pages ha-md-list ha-md-list-item {
+          background-color: var(--lcars-card-mid-color);
+          --md-list-item-label-text-color: var(--lcars-card-mid-text);
+          --md-list-item-supporting-text-color: var(--lcars-card-mid-text);
+          border-radius: 999px;
+          margin-block: 5px;
+        }
+
+        .pages ha-md-list ha-md-list-item:first-child {
+          background-color: var(--lcars-card-top-color);
+          --md-list-item-label-text-color: var(--lcars-card-top-text);
+          --md-list-item-supporting-text-color: var(--lcars-card-top-text);
+        }
+
+        .pages ha-md-list ha-md-list-item:last-child {
+          background-color: var(--lcars-card-bottom-color);
+          --md-list-item-label-text-color: var(--lcars-card-bottom-text);
+          --md-list-item-supporting-text-color: var(--lcars-card-bottom-text);
+        }
   # ===================================================== #
   #             USER PROFILE MODIFICATIONS                #
   # ===================================================== #
   card-mod-profile-yaml: |
     .: |
       :host {
-        /* Force these to be recomputed to prevent eager variable resolution    */
-        /* There are too many places in the settings pages that use light and   */
-        /* dark font on various background colors. We can't track them all.     */
-        /* The solution is to use a medium luminance background and default     */
-        /* to light text. Some places will use black, but that's still legible. */
         --lcars-primary-text: var(--lcars-text-light);
         --lcars-secondary-text: var(--lcars-text-light);
         --primary-text-color: var(--lcars-primary-text);
@@ -2470,18 +2976,12 @@
       div.bottom-bar {
         --header-height: 50px;
       }
-
   # ===================================================== #
   #                 DIALOG MODIFICATIONS                  #
   # ===================================================== #
   card-mod-dialog-yaml: |
     .: |
       :host {
-        /* Force these to be recomputed to prevent eager variable resolution    */
-        /* There are too many places in the settings pages that use light and   */
-        /* dark font on various background colors. We can't track them all.     */
-        /* The solution is to use a medium luminance background and default     */
-        /* to light text. Some places will use black, but that's still legible. */
         --lcars-primary-text: var(--lcars-text-light);
         --lcars-secondary-text: var(--lcars-text-light);
         --primary-text-color: var(--lcars-primary-text);
@@ -2512,11 +3012,6 @@
   card-mod-more-info-yaml: |
     .: |
       :host {
-        /* Force these to be recomputed to prevent eager variable resolution    */
-        /* There are too many places in the settings pages that use light and   */
-        /* dark font on various background colors. We can't track them all.     */
-        /* The solution is to use a medium luminance background and default     */
-        /* to light text. Some places will use black, but that's still legible. */
         --lcars-primary-text: var(--lcars-text-light);
         --lcars-secondary-text: var(--lcars-text-light);
         --primary-text-color: var(--lcars-primary-text);
@@ -2537,6 +3032,7 @@
         --mdc-text-field-ink-color: var(--lcars-primary-text);
         --wa-form-control-value-color: var(--lcars-primary-text);
       }
+
       button.breadcrumb {
         font-family: var(--font-family);
       }
@@ -2544,7 +3040,6 @@
       :host {
         font-family: var(--font-family);
       }
-
   # ===================================================== #
   #                 SIDEBAR MODIFICATIONS                 #
   # ===================================================== #
@@ -2555,7 +3050,6 @@
         padding: 0;
         align-items: stretch;
       }
-
     .: |
       :host {
         content: "";
@@ -2564,15 +3058,19 @@
         box-shadow: var(--lcars-background-color) 0px -130px 0px 0px;
         --menu-font-size: {{ states('input_number.lcars_menu_font') if has_value('input_number.lcars_menu_font') else 24 }}px;
       }
+
       .title {
         display: none !important;
       }
+
       .fade-top {
         display: none;
       }
+
       .fade-bottom {
         display: none;
       }
+
       .panels-list > .wrapper::before {
         content: "";
         position: absolute;
@@ -2580,8 +3078,8 @@
         left: 56px;
         height: calc(100% - 75px);
         border-left: 5px solid var(--lcars-background-color);
-      
       }
+
       ha-list-nav.before-spacer {
         margin-top: 70px;
         margin-bottom: 0px;
@@ -2590,10 +3088,12 @@
         border-top: 5px solid var(--lcars-background-color);
         font-family: var(--font-family);
       }
+
       ha-list-nav.after-spacer {
         padding: 0;
         margin: 0;
       }
+
       ha-list-item-button {
         border-bottom: 5px solid;
         background-color: var(--lcars-sidebar-item-color);
@@ -2602,127 +3102,131 @@
         border-radius: unset !important;
         border-color: var(--lcars-background-color);
         color: var(--lcars-sidebar-text) !important;
+      }
 
-        span.item-text,
-        span.badge {
-          font-family: var(--font-family);
-          text-align: right;
-          text-transform: uppercase;
-          line-height: 1;
-          color: var(--lcars-sidebar-text);
-        }
-        span.item-text {
-          font-size: var(--menu-font-size) !important;
-          align-content: center;
-          align-self: end;
-          box-sizing: border-box;
-          height: 100%;
-          min-height: 40px;
-          margin: 0px 0px 0px 0px;
-          padding: 9px 8px 11px 5px;
-          width: 100%;
-        }
-        span.badge {
-          position: absolute;
-          display: block;
-          top: unset;
-          left: 0px;
-          bottom: 0px;
-          background-color: var(--lcars-background-color);
-          border-radius: 0px;
-          height: 100%;
-          font-size: 38px;
-          line-height: 1;
-          min-width: 46px;
-          border-top: 0px solid var(--lcars-background-color);
-          overflow: hidden;
-          padding: 0 0 0 0;
-          margin: 0px;
-          text-align: center;
-          transition: font-size 0.2s ease;
-        }      
-      
-        &.configuration {
-          background-color: var(--lcars-ui-config-button);
+      ha-list-item-button span.item-text,
+      ha-list-item-button span.badge {
+        font-family: var(--font-family);
+        text-align: right;
+        text-transform: uppercase;
+        line-height: 1;
+        color: var(--lcars-sidebar-text);
+      }
 
-          > span.item-text {
-            color: var(--lcars-ui-config-button);
-            background-color: var(--lcars-background-color);
-            border: 3px var(--lcars-ui-config-button) solid;
-            padding-top: 6px;
-            padding-bottom: 8px;
-          }
+      ha-list-item-button span.item-text {
+        font-size: var(--menu-font-size) !important;
+        align-content: center;
+        align-self: end;
+        box-sizing: border-box;
+        height: 100%;
+        min-height: 40px;
+        margin: 0px 0px 0px 0px;
+        padding: 9px 8px 11px 5px;
+        width: 100%;
+      }
 
-          > span.badge {
-            color: var(--lcars-ui-config-icon);
-            border-left: 5px var(--lcars-ui-config-icon) solid;
-            border-right: 5px var(--lcars-ui-config-icon) solid;
-          }            
-          > ha-icon,
-          > ha-svg-icon {
-            color: var(--lcars-sidebar-text);
-            background-color: var(--lcars-ui-config-icon);
-          }     
-        }
+      ha-list-item-button span.badge {
+        position: absolute;
+        display: block;
+        top: unset;
+        left: 0px;
+        bottom: 0px;
+        background-color: var(--lcars-background-color);
+        border-radius: 0px;
+        height: 100%;
+        font-size: 38px;
+        line-height: 1;
+        min-width: 46px;
+        border-top: 0px solid var(--lcars-background-color);
+        overflow: hidden;
+        padding: 0 0 0 0;
+        margin: 0px;
+        text-align: center;
+        transition: font-size 0.2s ease;
+      }
 
-        &.notifications {
-          > span.badge {
-            color: var(--lcars-sidebar-notification-color) !important;
-            border-left: 5px var(--lcars-sidebar-notification-color) solid;
-            border-right: 5px var(--lcars-sidebar-notification-color) solid;
-          }
-        }
+      ha-list-item-button.configuration {
+        background-color: var(--lcars-ui-config-button);
+      }
 
-        &.user {
-          background-color: var(--lcars-sidebar-icon-background);
+      ha-list-item-button.configuration > span.item-text {
+        color: var(--lcars-ui-config-button);
+        background-color: var(--lcars-background-color);
+        border: 3px var(--lcars-ui-config-button) solid;
+        padding-top: 6px;
+        padding-bottom: 8px;
+      }
 
-          &:not(.selected) span.item-text {
-            color: var(--lcars-sidebar-icon-color);
-          }
+      ha-list-item-button.configuration > span.badge {
+        color: var(--lcars-ui-config-icon);
+        border-left: 5px var(--lcars-ui-config-icon) solid;
+        border-right: 5px var(--lcars-ui-config-icon) solid;
+      }
 
-        }
+      ha-list-item-button.configuration > ha-icon,
+      ha-list-item-button.configuration > ha-svg-icon {
+        color: var(--lcars-sidebar-text);
+        background-color: var(--lcars-ui-config-icon);
+      }
 
-        &.selected {
-          background-color: var(--lcars-sidebar-selected-color);
+      ha-list-item-button.notifications > span.badge {
+        color: var(--lcars-sidebar-notification-color) !important;
+        border-left: 5px var(--lcars-sidebar-notification-color) solid;
+        border-right: 5px var(--lcars-sidebar-notification-color) solid;
+      }
 
-          &::before {
-            display: none;
-          }
-          > span.item-text {
-            color: var(--lcars-sidebar-selected-color);
-            background-color: var(--lcars-background-color);
-            border: 3px var(--lcars-sidebar-selected-color) solid;
-            padding-top: 6px;
-            padding-bottom: 8px;
-          }
+      ha-list-item-button.user {
+        background-color: var(--lcars-sidebar-icon-background);
+      }
 
-          > ha-icon,
-          > ha-user-badge,
-          > ha-svg-icon {
-            background-color: var(--lcars-sidebar-selected-color);
-          }
-          > span.badge {
-            color: var(--lcars-sidebar-selected-color);
-            fill: var(--lcars-sidebar-selected-color);
-            border-left-color: var(--lcars-sidebar-selected-color);
-            border-right-color: var(--lcars-sidebar-selected-color);
-          }
-          > ha-user-badge {
-            margin-right: 0px;
-          }
-        }
+      ha-list-item-button.user:not(.selected) span.item-text {
+        color: var(--lcars-sidebar-icon-color);
+      }
+
+      ha-list-item-button.selected {
+        background-color: var(--lcars-sidebar-selected-color);
+      }
+
+      ha-list-item-button.selected::before {
+        display: none;
+      }
+
+      ha-list-item-button.selected > span.item-text {
+        color: var(--lcars-sidebar-selected-color);
+        background-color: var(--lcars-background-color);
+        border: 3px var(--lcars-sidebar-selected-color) solid;
+        padding-top: 6px;
+        padding-bottom: 8px;
+      }
+
+      ha-list-item-button.selected > ha-icon,
+      ha-list-item-button.selected > ha-user-badge,
+      ha-list-item-button.selected > ha-svg-icon {
+        background-color: var(--lcars-sidebar-selected-color);
+      }
+
+      ha-list-item-button.selected > span.badge {
+        color: var(--lcars-sidebar-selected-color);
+        fill: var(--lcars-sidebar-selected-color);
+        border-left-color: var(--lcars-sidebar-selected-color);
+        border-right-color: var(--lcars-sidebar-selected-color);
+      }
+
+      ha-list-item-button.selected > ha-user-badge {
+        margin-right: 0px;
       }
 
       div.menu {
         overflow: visible;
-
-        ha-icon-button {
-          margin-top: 150px;
-          margin-right: 94px;
-          margin-left: 0px;
-          z-index: 99;
-        }
       }
+
+      div.menu ha-icon-button {
+        margin-top: 150px;
+        margin-right: 94px;
+        margin-left: 0px;
+        z-index: 99;
+      }
+
       @media screen and (max-width: 870px) {
         .ha-scrollbar::before {
           content: "";
@@ -2751,31 +3255,42 @@
         background-color: var(--lcars-sidebar-item-color);
         border-right: 5px solid var(--lcars-background-color);
       }
+
       ha-user-badge {
         box-sizing: border-box;
         width: calc( var(--mdc-icon-size,24px) + 37px);
         padding-block: 8px;
       }
 
-      :host([expanded]) {
-        /* as of 2026.06, the 100% width isn't filling the slot */
-        width: var(--ha-sidebar-width);
-
-        ha-list-item-button:not(.selected) {
-          ha-icon,
-          ha-user-badge,
-          ha-svg-icon {
-            color: var(--lcars-sidebar-icon-color);
-            background-color: var(--lcars-sidebar-icon-background);
-          }
-        }
-        span.badge {
-          font-size: max( 38px, var(--menu-font-size) + 10px );
-        }
-        ha-user-badge {
-          padding-block: max( 8px, var(--menu-font-size)/2 - 2px );
-        }
+      ha-list-item-button:not(.configuration):not(.user) > ha-icon,
+      ha-list-item-button:not(.configuration):not(.user) > ha-svg-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        min-width: 61px;
+        height: 100%;
       }
+
+      :host([expanded]) {
+        width: var(--ha-sidebar-width);
+      }
+
+      :host([expanded]) ha-list-item-button:not(.selected) ha-icon,
+      :host([expanded]) ha-list-item-button:not(.selected) ha-user-badge,
+      :host([expanded]) ha-list-item-button:not(.selected) ha-svg-icon {
+        color: var(--lcars-sidebar-icon-color);
+        background-color: var(--lcars-sidebar-icon-background);
+      }
+
+      :host([expanded]) span.badge {
+        font-size: max( 38px, var(--menu-font-size) + 10px );
+      }
+
+      :host([expanded]) ha-user-badge {
+        padding-block: max( 8px, var(--menu-font-size)/2 - 2px );
+      }
+
       .divider {
         display: none;
       }
@@ -2790,7 +3305,6 @@
         padding-right: 20px;
         border-radius: 0px 999px 999px 9px;
       }
-
 # ======================================================= #
 #                    THEME DEFINITIONS                    #
 # ======================================================= #


### PR DESCRIPTION
**Stacked on #238** — based on `fix-button-block-merge-artifact` because master's CSS is currently broken (unbalanced braces); retargets to `master` automatically when #238 merges.

Raised by Discord user @sogtwinster.

## Summary

The collapsed sidebar's hover tooltip (dashboard names) rendered **black text on a black background** in dark mode. `ha-tooltip`'s theme hooks were unset, so its background fell back to `--ha-color-surface-default` (HA's near-black in dark mode) while its text rode the `--primary-text-color` chain, which resolves dark in several scopes.

Variable chain (source-verified against shipped frontend tags):

```
text:  --wa-tooltip-content-color → var(--ha-tooltip-text-color, var(--primary-text-color))
bg:    --wa-tooltip-background-color → var(--ha-tooltip-background-color, var(--ha-color-surface-default))
```

## Fix

Add a semantic pair the theme owns, defined per mode in `defaults.yaml`:

| Mode | `lcars-tooltip-background` | `lcars-tooltip-text` |
|---|---|---|
| light | `ui-quaternary` | `ui-quaternary-text` |
| dark | `background-color` (black) | `background-text` (white, 21:1) |

and map `ha-tooltip-background-color` / `ha-tooltip-text-color` to them in `&base`. Theme level rather than `#view` scope deliberately: the broken tooltip belongs to `ha-sidebar`, which lives outside `#view` — the `&base` mapping reaches every `ha-tooltip` in the app (sidebar, header icons, settings). Both hooks sit first in ha-tooltip's fallback chains and nothing else defines them, so the collision is structurally gone. Themes can override the pair per mode.

## Test plan

- [x] Generator clean; both mode blocks emit the pair in all 24 themes; contrast verifier passes; flat file regenerated
- [x] Live: hover a collapsed-sidebar item in dark mode (white on black) and light mode (quaternary pair)
- [x] Spot-check another tooltip surface (header icon hover) in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMn5SX9ZesgNieWqQT7CJi