### PR TITLE
fix(ci): force-push rebased release-impact branch

### DIFF
--- a/.github/workflows/release-impact-beta.yml
+++ b/.github/workflows/release-impact-beta.yml
@@ -52,3 +52,6 @@ jobs:
         with:
           commit_message: "chore: add ha-frontend pre-release pipeline impact analysis"
           file_pattern: "docs/release-impact/pipeline-*.md"
+          # The Rebase Branch step rewrites history when master has moved,
+          # so the push is non-fast-forward by design.
+          push_options: '--force-with-lease'

--- a/.github/workflows/release-impact.yml
+++ b/.github/workflows/release-impact.yml
@@ -47,3 +47,6 @@ jobs:
         with:
           commit_message: "chore: add ha-frontend release impact analyses"
           file_pattern: "docs/release-impact/*.md docs/release-impact/.state.json"
+          # The Rebase Branch step rewrites history when master has moved,
+          # so the push is non-fast-forward by design.
+          push_options: '--force-with-lease'


### PR DESCRIPTION
## Summary

Every scheduled HA-Frontend Release Impact Analysis run since July 12 has failed at the final push:

```
! [rejected]  ha-frontend-release-impact-analysis -> ha-frontend-release-impact-analysis (non-fast-forward)
```

**Root cause:** fallout from #235 working as intended. Now that the Rebase Branch step actually rebases the analysis branch onto `origin/master`, the branch history is rewritten whenever master has moved — making the plain push from `git-auto-commit-action` non-fast-forward. July 10–11 passed only because master hadn't changed (rebase was a no-op). Before #235, the silent rebase failure meant history was never rewritten, so the flaw in the original design (rebase + plain push) was never exercised.

**Cost of the failures:** each failed run loses both the analysis report and the `.state.json` update, so the analyzer has been re-analyzing the same frontend pin — and spending an Anthropic API call — every night since the 12th.

## Fix

Add `push_options: '--force-with-lease'` to the auto-commit step in both `release-impact.yml` and `release-impact-beta.yml` (same rebase-then-push pattern). The lease is taken against the refs fetched at checkout, so a genuinely concurrent push to the branch still rejects instead of being clobbered.

Note: as a `schedule`-triggered workflow, the fix takes effect on the next run **after this merges to master**.

## Test plan

- [x] Both workflow files parse
- [ ] After merge: next scheduled run pushes successfully and `.state.json` advances past the current pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMn5SX9ZesgNieWqQT7CJi